### PR TITLE
Installing swig3 on centOS

### DIFF
--- a/.github/workflows/install_centos_dependencies_build.sh
+++ b/.github/workflows/install_centos_dependencies_build.sh
@@ -17,7 +17,7 @@ yum install -y make
 yum install -y flex
 yum install -y bison
 yum install -y readline-devel
-yum install -y swig
+yum install -y swig3
 yum install -y which
 yum install -y google-perftools
 yum install -y gperftools gperftools-devel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ if (NOT APPLE) # Currently OpenFPGA doesn't build on MacOS
     add_subdirectory(OpenFPGA_RS)
 endif()
 
+# Require swig 3
+find_package(SWIG 3.0 REQUIRED)
+
 # Check system 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 


### PR DESCRIPTION
Bumping up the swig version on centOS from 2.0.x to 3.0.x