### PR TITLE
build_deps: Add automake & autoconf to the Ubuntu build dependencies script

### DIFF
--- a/.github/workflows/install_ubuntu_dependencies_build.sh
+++ b/.github/workflows/install_ubuntu_dependencies_build.sh
@@ -30,6 +30,8 @@ sudo apt install -y \
   libboost-python-dev \
   libboost-filesystem-dev \
   zlib1g-dev \
+  automake \
+  autoconf \
   ninja-build 
   
 sudo ln -sf /usr/bin/g++-9 /usr/bin/g++


### PR DESCRIPTION
The build fails on Ubuntu 20.04 LTS server installs without automake and autoconf