### PR TITLE
Fixed empty git hash issue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ set(VERSION_MAJOR 0)
 set(VERSION_MINOR 1)
 set(VERSION_PATCH 9)
 
-execute_process(COMMAND git rev-parse --short HEAD
+execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND git rev-parse --short HEAD
   COMMAND tr -d '\n'
   OUTPUT_VARIABLE GIT_HASH
   ERROR_VARIABLE GIT_HASH_ERR


### PR DESCRIPTION
This change fixes the [Installed raptor does not show git hash](https://github.com/RapidSilicon/Raptor/issues/101) issue. The PR at [https://github.com/os-fpga/FOEDAG/pull/501](https://github.com/os-fpga/FOEDAG/pull/501) should be merged and FOEDAG, FOEDAG_rs submodules should be updated for a complete fix of the issue.