### PR TITLE
Update gemini vpr xml file with latest deliver from HW/IP team (6129c…

### DIFF
--- a/etc/devices/gemini/gemini_vpr.xml
+++ b/etc/devices/gemini/gemini_vpr.xml
@@ -89,6 +89,48 @@
         <port name="Q" clock="C"/>
       </output_ports>
     </model>
+    <model name="sdffsre">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+        <port name="E" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="S" clock="C"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="sdffnsre">
+      <input_ports>
+        <port name="D" clock="C"/>
+        <port name="C" is_clock="1"/>
+        <port name="E" clock="C"/>
+        <port name="R" clock="C"/>
+        <port name="S" clock="C"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="C"/>
+      </output_ports>
+    </model>
+    <model name="latch">
+      <input_ports>
+        <port name="G" is_clock="1" />
+        <port name="D" clock="G"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="G"/>
+      </output_ports>
+    </model>
+    <model name="latchn">
+      <input_ports>
+        <port name="G" is_clock="1" />
+        <port name="D" clock="G"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q" clock="G"/>
+      </output_ports>
+    </model>
     <model name="latchsre">
       <input_ports>
         <port name="G" is_clock="1" />
@@ -130,6 +172,8 @@
         <port name="SI" clock="clk"/>
         <port name="S" clock="clk"/>
         <port name="R" clock="clk"/>
+        <port name="SYNC_S" clock="clk"/>
+        <port name="SYNC_R" clock="clk"/>
         <port name="E" clock="clk"/>
         <port name="clk" is_clock="1"/>
       </input_ports>
@@ -208,8 +252,10 @@
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
+        <port name="feedback"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
+        <port name="reset"/>
       </input_ports>
       <output_ports>
         <port name="z"/>
@@ -222,9 +268,11 @@
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
+        <port name="feedback" clock="clk"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -237,9 +285,11 @@
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
+        <port name="feedback" clock="clk"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -252,9 +302,11 @@
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
+        <port name="feedback" clock="clk"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -265,11 +317,18 @@
         <port name="a" combinational_sink_ports="z"/>
         <port name="b" combinational_sink_ports="z"/>
         <port name="subtract" combinational_sink_ports="z"/>
+        <port name="load_acc"/>
+        <port name="acc_fir" combinational_sink_ports="z"/>
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
+        <port name="feedback"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z"/>
@@ -282,12 +341,17 @@
         <port name="subtract" clock="clk"/>
         <port name="feedback" clock="clk"/>
         <port name="load_acc" clock="clk"/>
+        <port name="acc_fir" clock="clk"/>
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -300,12 +364,17 @@
         <port name="subtract" clock="clk"/>
         <port name="feedback" clock="clk"/>
         <port name="load_acc" clock="clk"/>
+        <port name="acc_fir" clock="clk"/>
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -318,12 +387,17 @@
         <port name="subtract" clock="clk" combinational_sink_ports="z"/>
         <port name="feedback" clock="clk"/>
         <port name="load_acc" clock="clk"/>
+        <port name="acc_fir" clock="clk" combinational_sink_ports="z"/>
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -335,12 +409,17 @@
         <port name="b" clock="clk"/>
         <port name="subtract" clock="clk"/>
         <port name="feedback" clock="clk"/>
+        <port name="load_acc" clock="clk"/>
         <port name="unsigned_a"/>
         <port name="unsigned_b"/>
         <port name="f_mode"/>
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -359,6 +438,10 @@
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -377,6 +460,10 @@
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -395,6 +482,10 @@
         <port name="output_select"/>
         <port name="register_inputs"/>
         <port name="clk" is_clock="1"/>
+        <port name="reset"/>
+        <port name="saturate_enable"/>
+        <port name="shift_right"/>
+        <port name="round"/>
       </input_ports>
       <output_ports>
         <port name="z" clock="clk"/>
@@ -609,6 +700,8 @@
       <input name="cin_trick" num_pins="1"/>
       <input name="set" num_pins="1"/>
       <input name="lreset" num_pins="1"/>
+      <input name="sync_set" num_pins="1"/>
+      <input name="sync_reset" num_pins="1"/>
       <input name="reset" num_pins="1" is_non_clock_global="true"/>
       <input name="scan_reset" num_pins="1" is_non_clock_global="true"/>
       <input name="enable" num_pins="1"/>
@@ -637,22 +730,11 @@
            We keep all the pins that touch routing architecture on the right and bottom sides of the tile
            Top side pins are mainly for direct connections
         -->
-      <!-- <pinlocations pattern="custom">
-        <loc side="left"> clb.clk clb.scan_reset clb.reset</loc>
-        <loc side="top">  clb.cin clb.sc_in clb.enable clb.reg_in clb.cin_trick
-                          clb.I0[7:0] clb.I1[7:0] clb.O[7:0]</loc>
-        <loc side="right">clb.set clb.lreset
-                          clb.I2[7:0] clb.I3[7:0] clb.O[17:10]</loc>
-        <loc side="bottom">clb.sc_out clb.cout clb.reg_out 
-                           clb.I0[9:8] clb.I1[9:8] 
-                           clb.I2[9:8] clb.I3[9:8]
-                           clb.O[9:8] clb.O[19:18]</loc>
-      </pinlocations> -->
       <pinlocations pattern="custom">
         <loc side="left"> clb.clk clb.scan_reset clb.reset</loc>
         <loc side="top">  clb.cin clb.sc_in clb.enable clb.reg_in clb.cin_trick
                           clb.I0[9:0] clb.I1[9:0] clb.O[9:0]</loc>
-        <loc side="right">clb.set clb.lreset
+        <loc side="right">clb.set clb.lreset clb.sync_set clb.sync_reset
                           clb.I2[9:0] clb.I3[9:0] clb.O[19:10]</loc>
         <loc side="bottom">clb.sc_out clb.cout clb.reg_out</loc>
       </pinlocations>
@@ -842,10 +924,10 @@
     <connection_block input_switch_name="ipin_cblock"/>
   </device>
   <switchlist>
-    <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="0" Tdel="2.51877e-10" mux_trans_size="1.222260" buf_size="auto"/>
-    <switch type="mux" name="L1_mux" R="0." Cin=".77e-15" Cout="0." Tdel="2.42823e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="0" Tdel="1.637e-10" mux_trans_size="1.222260" buf_size="auto"/>
+    <switch type="mux" name="L1_mux" R="0." Cin=".77e-15" Cout="0." Tdel="1.08e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
     <switch type="mux" name="L2_mux" R="0." Cin=".77e-15" Cout="0." Tdel="1e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <switch type="mux" name="L4_mux" R="0." Cin=".77e-15" Cout="0." Tdel="2.16839e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="0." Cin=".77e-15" Cout="0." Tdel="1.2e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
   </switchlist>
   <segmentlist>
     <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
@@ -1155,6 +1237,8 @@
       <input name="cin_trick" num_pins="1"/>
       <input name="set" num_pins="1"/>
       <input name="lreset" num_pins="1"/>
+      <input name="sync_set" num_pins="1"/>
+      <input name="sync_reset" num_pins="1"/>
       <input name="reset" num_pins="1" is_non_clock_global="true"/>
       <input name="scan_reset" num_pins="1" is_non_clock_global="true"/>
       <input name="enable" num_pins="1"/>
@@ -1171,6 +1255,8 @@
         <input name="sc_in" num_pins="1"/>
         <input name="set" num_pins="1"/>
         <input name="reset" num_pins="1"/>
+        <input name="sync_set" num_pins="1"/>
+        <input name="sync_reset" num_pins="1"/>
         <input name="enable" num_pins="1"/>
         <input name="reg_in" num_pins="1"/>
         <output name="out" num_pins="2"/>
@@ -1182,27 +1268,29 @@
         <!-- Timing annotation is not require for unpackable mode
              It will not be used by timing analyzer
           -->
-	      <mode name="physical" disable_packing="true">
+	<mode name="physical" disable_packing="true">
           <pb_type name="fabric" num_pb="1">
-            <input name="in" num_pins="6"/>
-            <input name="cin" num_pins="1"/>
-            <input name="sc_in" num_pins="1"/>
-            <input name="set" num_pins="1"/>
-            <input name="reset" num_pins="1"/>
-            <input name="enable" num_pins="1"/>
-            <input name="reg_in" num_pins="1"/>
-            <output name="out" num_pins="2"/>
-            <output name="cout" num_pins="1"/>
-            <output name="sc_out" num_pins="1"/>
-            <output name="reg_out" num_pins="1"/>
-            <clock name="clk" num_pins="1"/>
-            <pb_type name="frac_logic" num_pb="1">
-              <input name="in" num_pins="6"/>
-              <input name="cin" num_pins="1"/>
-              <input name="reg_in" num_pins="1"/>
+	    <input name="in" num_pins="6"/>
+	    <input name="cin" num_pins="1"/>
+	    <input name="sc_in" num_pins="1"/>
+	    <input name="set" num_pins="1"/>
+	    <input name="reset" num_pins="1"/>
+	    <input name="sync_set" num_pins="1"/>
+	    <input name="sync_reset" num_pins="1"/>
+	    <input name="enable" num_pins="1"/>
+	    <input name="reg_in" num_pins="1"/>
+	    <output name="out" num_pins="2"/>
+	    <output name="cout" num_pins="1"/>
+	    <output name="sc_out" num_pins="1"/>
+	    <output name="reg_out" num_pins="1"/>
+	    <clock name="clk" num_pins="1"/>
+	    <pb_type name="frac_logic" num_pb="1">
+	      <input name="in" num_pins="6"/>
+	      <input name="cin" num_pins="1"/>
+	      <input name="reg_in" num_pins="1"/>
               <input name="regchain" num_pins="1"/>
-              <output name="cout" num_pins="1"/>
-              <output name="out" num_pins="2"/>
+	      <output name="cout" num_pins="1"/>
+	      <output name="out" num_pins="2"/>
               <pb_type name="frac_lut6" blif_model=".subckt frac_lut6" num_pb="1">
                 <input name="in" num_pins="6"/>
                 <output name="lut4_out" num_pins="4"/>
@@ -1307,12 +1395,12 @@
                 <input name="cin" num_pins="1"/>
                 <output name="sumout" num_pins="1"/>
                 <output name="cout" num_pins="1"/>
-                <delay_constant max="5e-11" min="4e-11" in_port="adder_carry.p" out_port="adder_carry.sumout"/>
-                <delay_constant max="8.9626e-11" min="8.2339e-11" in_port="adder_carry.g" out_port="adder_carry.sumout"/>
-                <delay_constant max="5e-11" min="3e-11" in_port="adder_carry.cin" out_port="adder_carry.sumout"/>
-                <delay_constant max="5e-11" min="3e-11" in_port="adder_carry.p" out_port="adder_carry.cout"/>
-                <delay_constant max="5e-11" min="3e-11" in_port="adder_carry.g" out_port="adder_carry.cout"/>
-                <delay_constant max="5e-11" min="4e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
+		<delay_constant max="5e-11" min="4e-11" in_port="adder_carry.p" out_port="adder_carry.sumout"/>
+		<delay_constant max="8.9626e-11" min="8.2339e-11" in_port="adder_carry.g" out_port="adder_carry.sumout"/>
+		<delay_constant max="5e-11" min="3e-11" in_port="adder_carry.cin" out_port="adder_carry.sumout"/>
+		<delay_constant max="5e-11" min="3e-11" in_port="adder_carry.p" out_port="adder_carry.cout"/>
+		<delay_constant max="5e-11" min="3e-11" in_port="adder_carry.g" out_port="adder_carry.cout"/>
+		<delay_constant max="5e-11" min="4e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
               </pb_type>
               <interconnect>
                 <direct name="direct1" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
@@ -1340,63 +1428,71 @@
                 </mux>
               </interconnect>
             </pb_type>
-	          <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
-              <input name="D" num_pins="1"/>
-              <input name="SI" num_pins="1"/>
-              <output name="SO" num_pins="1"/>
-              <input name="S" num_pins="1"/>
-              <input name="R" num_pins="1"/>
-              <input name="E" num_pins="1"/>
-              <output name="Q" num_pins="1"/>
-              <clock name="clk" num_pins="1"/>
-              <T_setup value="6.34486e-11" port="ff_phy.D" clock="clk"/>
-              <T_setup value="7.42229e-11" port="ff_phy.SI" clock="clk"/>
-              <T_setup value="8.14058e-11" port="ff_phy.E" clock="clk"/>
-              <T_setup value="-6.704e-11" port="ff_phy.S" clock="clk"/>
-              <T_setup value="-8.73915e-11" port="ff_phy.R" clock="clk"/>
-              <T_clock_to_Q max="1.2189e-10" port="ff_phy.Q" clock="clk"/> <!--ideal clock to Q-->
-              <T_clock_to_Q max="6.27806e-10" port="ff_phy.SO" clock="clk"/>
-	          </pb_type>
-	          <interconnect>
-              <complete name="direct_clk" input="fabric.clk" output="ff_phy[1:0].clk"/>
-              <complete name="direct_reset" input="fabric.reset" output="ff_phy[1:0].R"/>
-              <complete name="direct_set" input="fabric.set" output="ff_phy[1:0].S"/>
-              <complete name="direct_enable" input="fabric.enable" output="ff_phy[1:0].E"/>
-              <direct name="direct_in" input="fabric.in[5:0]" output="frac_logic.in[5:0]"/>
-              <direct name="direct_cin" input="fabric.cin" output="frac_logic.cin"/>
-              <direct name="direct_reg_in" input="fabric.reg_in" output="frac_logic.reg_in"/>
-                    <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
-              <direct name="direct_cout" input="frac_logic.cout" output="fabric.cout"/>
-              <direct name="direct_reg_out" input="ff_phy[1].Q" output="fabric.reg_out"/>
-              <direct name="direct_fabric_scin" input="fabric.sc_in" output="ff_phy[0].SI"/>
-              <direct name="direct_fabric_sc_chain" input="ff_phy[0].SO" output="ff_phy[1].SI"/>
-	            <direct name="direct_fabric_scout" input="ff_phy[1].SO" output="fabric.sc_out"/>
+	    <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
+	      <input name="D" num_pins="1"/>
+	      <input name="SI" num_pins="1"/>
+	      <output name="SO" num_pins="1"/>
+	      <input name="S" num_pins="1"/>
+	      <input name="R" num_pins="1"/>
+	      <input name="SYNC_S" num_pins="1"/>
+	      <input name="SYNC_R" num_pins="1"/>
+	      <input name="E" num_pins="1"/>
+	      <output name="Q" num_pins="1"/>
+	      <clock name="clk" num_pins="1"/>
+	      <T_setup value="6.34486e-11" port="ff_phy.D" clock="clk"/>
+	      <T_setup value="7.42229e-11" port="ff_phy.SI" clock="clk"/>
+	      <T_setup value="8.14058e-11" port="ff_phy.E" clock="clk"/>
+	      <T_setup value="-6.704e-11" port="ff_phy.S" clock="clk"/>
+	      <T_setup value="-8.73915e-11" port="ff_phy.R" clock="clk"/>
+	      <T_setup value="-6.704e-11" port="ff_phy.SYNC_S" clock="clk"/>
+	      <T_setup value="-8.73915e-11" port="ff_phy.SYNC_R" clock="clk"/>
+	      <T_clock_to_Q max="7.09448e-10" port="ff_phy.Q" clock="clk"/>
+	      <T_clock_to_Q max="6.27806e-10" port="ff_phy.SO" clock="clk"/>
+	    </pb_type>
+	    <interconnect>
+	      <complete name="direct_clk" input="fabric.clk" output="ff_phy[1:0].clk"/>
+	      <complete name="direct_reset" input="fabric.reset" output="ff_phy[1:0].R"/>
+	      <complete name="direct_set" input="fabric.set" output="ff_phy[1:0].S"/>
+	      <complete name="direct_enable" input="fabric.enable" output="ff_phy[1:0].E"/>
+	      <complete name="direct_sync_reset" input="fabric.sync_reset" output="ff_phy[1:0].SYNC_R"/>
+	      <complete name="direct_sync_set" input="fabric.sync_set" output="ff_phy[1:0].SYNC_S"/>
+	      <direct name="direct_in" input="fabric.in[5:0]" output="frac_logic.in[5:0]"/>
+	      <direct name="direct_cin" input="fabric.cin" output="frac_logic.cin"/>
+	      <direct name="direct_reg_in" input="fabric.reg_in" output="frac_logic.reg_in"/>
+              <direct name="direct_regchain" input="ff_phy[0].Q" output="frac_logic.regchain"/>
+	      <direct name="direct_cout" input="frac_logic.cout" output="fabric.cout"/>
+	      <direct name="direct_reg_out" input="ff_phy[1].Q" output="fabric.reg_out"/>
+	      <direct name="direct_fabric_scin" input="fabric.sc_in" output="ff_phy[0].SI"/>
+	      <direct name="direct_fabric_sc_chain" input="ff_phy[0].SO" output="ff_phy[1].SI"/>
+	      <direct name="direct_fabric_scout" input="ff_phy[1].SO" output="fabric.sc_out"/>
               <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
               <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
-	            <mux name="mux2" input="frac_logic.out[0] ff_phy[0].Q" output="fabric.out[0]">
+	      <mux name="mux2" input="frac_logic.out[0] ff_phy[0].Q" output="fabric.out[0]">
                 <delay_constant max="9.6058e-11" min="8.359e-11" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
                 <delay_constant max="1.00905e-10" min="8.9674e-11" in_port="ff_phy[0].Q" out_port="fabric.out[0]"/>
               </mux>
-	            <mux name="mux3" input="frac_logic.out[1] ff_phy[1].Q" output="fabric.out[1]">
+	      <mux name="mux3" input="frac_logic.out[1] ff_phy[1].Q" output="fabric.out[1]">
                 <delay_constant max="9.6361e-11" min="8.4919e-11" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
                 <delay_constant max="1.42435e-10" min="9.1011e-11" in_port="ff_phy[1].Q" out_port="fabric.out[1]"/>
               </mux>
-	          </interconnect>
+	    </interconnect>
           </pb_type>
-        <interconnect>
-          <direct name="direct1" input="fle.in" output="fabric.in"/>
-          <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
-          <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
-          <direct name="direct4" input="fle.cin" output="fabric.cin"/>
-          <direct name="direct5" input="fabric.out" output="fle.out"/>
-          <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
-          <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
-          <direct name="direct8" input="fabric.cout" output="fle.cout"/>
-          <direct name="direct9" input="fle.clk" output="fabric.clk"/>
-          <direct name="direct10" input="fle.reset" output="fabric.reset"/>
-          <direct name="direct11" input="fle.set" output="fabric.set"/>
-          <direct name="direct12" input="fle.enable" output="fabric.enable"/>
-        </interconnect>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="fabric.in"/>
+            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+            <direct name="direct5" input="fabric.out" output="fle.out"/>
+            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+            <direct name="direct11" input="fle.set" output="fabric.set"/>
+            <direct name="direct12" input="fle.enable" output="fabric.enable"/>
+            <direct name="direct13" input="fle.sync_reset" output="fabric.sync_reset"/>
+            <direct name="direct14" input="fle.sync_set" output="fabric.sync_set"/>
+          </interconnect>
         </mode>
         <!-- Define physical mode ends -->
         <mode name="n1_lut6">
@@ -1404,6 +1500,8 @@
             <input name="in" num_pins="6"/>
             <input name="set" num_pins="1"/>
             <input name="reset" num_pins="1"/>
+            <input name="sync_set" num_pins="1"/>
+            <input name="sync_reset" num_pins="1"/>
             <input name="enable" num_pins="1"/>
             <output name="out" num_pins="1"/>
             <clock name="clk" num_pins="1"/>
@@ -1431,144 +1529,263 @@
               <input name="D" num_pins="1"/>
               <input name="S" num_pins="1"/>
               <input name="R" num_pins="1"/>
+              <input name="SYNC_S" num_pins="1"/>
+              <input name="SYNC_R" num_pins="1"/>
               <input name="E" num_pins="1"/>
               <output name="Q" num_pins="1"/>
               <clock name="clk" num_pins="1"/>
-              <mode name="LATCH">
-                <pb_type name="LATCH" blif_model=".latch" num_pb="1" class="flipflop">
+
+              <mode name="native_latch">
+                <pb_type name="native_latch" blif_model=".latch" num_pb="1" class="flipflop">
                   <input  name="D" num_pins="1" port_class="D"/>
                   <output name="Q" num_pins="1" port_class="Q"/>
                   <clock  name="clk" num_pins="1" port_class="clock"/>
-                  <T_setup      value="6.34486e-11" port="LATCH.D" clock="clk"/>
-                  <T_hold       value="2.87314e-11" port="LATCH.D" clock="clk"/>
-                  <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="LATCH.Q" clock="clk"/>
+                  <T_setup value="6.34486e-11" port="native_latch.D" clock="clk"/>
+                  <T_hold  value="2.87314e-11"  port="native_latch.D" clock="clk"/>
+                  <T_clock_to_Q max="7.09448e-10" min="4.08795e-10" port="native_latch.Q" clock="clk"/>
                 </pb_type>
                 <interconnect>
-                  <direct input="LATCH.Q" name="LATCH-Q" output="ff.Q">
-                  </direct>
-                  <direct input="ff.D" name="LATCH-D" output="LATCH.D">
-                  </direct>
-                  <direct input="ff.clk" name="LATCH-clk" output="LATCH.clk"/>
+                  <direct  name="Q"   input="native_latch.Q" output="ff.Q"/>
+                  <direct  name="D"   input="ff.D"           output="native_latch.D"/>
+                  <direct  name="clk" input="ff.clk"         output="native_latch.clk"/>
+                </interconnect>
+              </mode>
+
+              <mode name="DFF">
+                <pb_type name="DFF" num_pb="1" blif_model=".subckt dff">
+                  <input  name="D" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <clock  name="C" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="DFF.D" clock="C"/>
+                  <T_hold  value="2.87314e-11" port="DFF.D" clock="C"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFF.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="DFF.D"/>
+                  <direct name="Q_to_Q" input="DFF.Q" output="ff.Q"/>
+                  <direct name="clk_to_C" input="ff.clk" output="DFF.C"/>
+                </interconnect>
+              </mode>
+              <mode name="DFFN">
+                <pb_type name="DFFN" num_pb="1" blif_model=".subckt dffn">
+                  <input  name="D" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <clock  name="C" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="DFFN.D" clock="C"/>
+                  <T_hold  value="2.87314e-11" port="DFFN.D" clock="C"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFFN.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="DFFN.D"/>
+                  <direct name="Q_to_Q" input="DFFN.Q" output="ff.Q"/>
+                  <direct name="clk_to_C" input="ff.clk" output="DFFN.C"/>
+                </interconnect>
+              </mode>
+              <mode name="DFFSRE">
+                <pb_type name="DFFSRE" num_pb="1" blif_model=".subckt dffsre">
+                  <input  name="D" num_pins="1"/>
+                  <input  name="S" num_pins="1"/>
+                  <input  name="R" num_pins="1"/>
+                  <input  name="E" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <clock  name="C" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="DFFSRE.D" clock="C"/>
+                  <T_hold  value="2.87314e-11" port="DFFSRE.D" clock="C"/>
+                  <T_setup value="-6.704e-11" port="DFFSRE.S" clock="C"/>
+                  <T_hold  value="8.85886e-11" port="DFFSRE.S" clock="C"/>
+                  <T_setup value="-8.73915e-11" port="DFFSRE.R" clock="C"/>
+                  <T_hold  value="1.3408e-10" port="DFFSRE.R" clock="C"/>
+                  <T_setup value="8.14058e-11" port="DFFSRE.E" clock="C"/>
+                  <T_hold  value="1.07743e-11" port="DFFSRE.E" clock="C"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFFSRE.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="DFFSRE.D"/>
+                  <direct name="S_to_S" input="ff.S" output="DFFSRE.S"/>
+                  <direct name="R_to_R" input="ff.R" output="DFFSRE.R"/>
+                  <direct name="E_to_E" input="ff.E" output="DFFSRE.E"/>
+                  <direct name="Q_to_Q" input="DFFSRE.Q" output="ff.Q"/>
+                  <direct name="clk_to_C" input="ff.clk" output="DFFSRE.C"/>
+                </interconnect>
+              </mode>
+              <mode name="DFFNSRE">
+                <pb_type name="DFFNSRE" num_pb="1" blif_model=".subckt dffnsre">
+                  <input  name="D" num_pins="1"/>
+                  <input  name="S" num_pins="1"/>
+                  <input  name="R" num_pins="1"/>
+                  <input  name="E" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <clock  name="C" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="DFFNSRE.D" clock="C"/>
+                  <T_hold  value="2.87314e-11" port="DFFNSRE.D" clock="C"/>
+                  <T_setup value="-6.704e-11" port="DFFNSRE.S" clock="C"/>
+                  <T_hold  value="8.85886e-11" port="DFFNSRE.S" clock="C"/>
+                  <T_setup value="-8.73915e-11" port="DFFNSRE.R" clock="C"/>
+                  <T_hold  value="1.3408e-10" port="DFFNSRE.R" clock="C"/>
+                  <T_setup value="8.14058e-11" port="DFFNSRE.E" clock="C"/>
+                  <T_hold  value="1.07743e-11" port="DFFNSRE.E" clock="C"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFFNSRE.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="DFFNSRE.D"/>
+                  <direct name="S_to_S" input="ff.S" output="DFFNSRE.S"/>
+                  <direct name="R_to_R" input="ff.R" output="DFFNSRE.R"/>
+                  <direct name="E_to_E" input="ff.E" output="DFFNSRE.E"/>
+                  <direct name="Q_to_Q" input="DFFNSRE.Q" output="ff.Q"/>
+                  <direct name="clk_to_C" input="ff.clk" output="DFFNSRE.C"/>
+                </interconnect>
+              </mode>
+              <mode name="SDFFSRE">
+                <pb_type name="SDFFSRE" num_pb="1" blif_model=".subckt sdffsre">
+                  <input  name="D" num_pins="1"/>
+                  <input  name="S" num_pins="1"/>
+                  <input  name="R" num_pins="1"/>
+                  <input  name="E" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <clock  name="C" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="SDFFSRE.D" clock="C"/>
+                  <T_hold  value="2.87314e-11" port="SDFFSRE.D" clock="C"/>
+                  <T_setup value="-6.704e-11" port="SDFFSRE.S" clock="C"/>
+                  <T_hold  value="8.85886e-11" port="SDFFSRE.S" clock="C"/>
+                  <T_setup value="-8.73915e-11" port="SDFFSRE.R" clock="C"/>
+                  <T_hold  value="1.3408e-10" port="SDFFSRE.R" clock="C"/>
+                  <T_setup value="8.14058e-11" port="SDFFSRE.E" clock="C"/>
+                  <T_hold  value="1.07743e-11" port="SDFFSRE.E" clock="C"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="SDFFSRE.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="SDFFSRE.D"/>
+                  <direct name="S_to_S" input="ff.SYNC_S" output="SDFFSRE.S"/>
+                  <direct name="R_to_R" input="ff.SYNC_R" output="SDFFSRE.R"/>
+                  <direct name="E_to_E" input="ff.E" output="SDFFSRE.E"/>
+                  <direct name="Q_to_Q" input="SDFFSRE.Q" output="ff.Q"/>
+                  <direct name="clk_to_C" input="ff.clk" output="SDFFSRE.C"/>
+                </interconnect>
+              </mode>
+              <mode name="SDFFNSRE">
+                <pb_type name="SDFFNSRE" num_pb="1" blif_model=".subckt sdffnsre">
+                  <input  name="D" num_pins="1"/>
+                  <input  name="S" num_pins="1"/>
+                  <input  name="R" num_pins="1"/>
+                  <input  name="E" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <clock  name="C" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="SDFFNSRE.D" clock="C"/>
+                  <T_hold  value="2.87314e-11" port="SDFFNSRE.D" clock="C"/>
+                  <T_setup value="-6.704e-11" port="SDFFNSRE.S" clock="C"/>
+                  <T_hold  value="8.85886e-11" port="SDFFNSRE.S" clock="C"/>
+                  <T_setup value="-8.73915e-11" port="SDFFNSRE.R" clock="C"/>
+                  <T_hold  value="1.3408e-10" port="SDFFNSRE.R" clock="C"/>
+                  <T_setup value="8.14058e-11" port="SDFFNSRE.E" clock="C"/>
+                  <T_hold  value="1.07743e-11" port="SDFFNSRE.E" clock="C"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="SDFFNSRE.Q" clock="C"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="SDFFNSRE.D"/>
+                  <direct name="S_to_S" input="ff.SYNC_S" output="SDFFNSRE.S"/>
+                  <direct name="R_to_R" input="ff.SYNC_R" output="SDFFNSRE.R"/>
+                  <direct name="E_to_E" input="ff.E" output="SDFFNSRE.E"/>
+                  <direct name="Q_to_Q" input="SDFFNSRE.Q" output="ff.Q"/>
+                  <direct name="clk_to_C" input="ff.clk" output="SDFFNSRE.C"/>
+                </interconnect>
+              </mode>
+              <mode name="LATCH">
+                <pb_type name="LATCH" num_pb="1" blif_model=".subckt latch">
+                  <input  name="D" num_pins="1"/>
+                  <clock  name="G" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="LATCH.D" clock="G"/>
+                  <T_hold  value="2.87314e-11" port="LATCH.D" clock="G"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCH.Q" clock="G"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="LATCH.D"/>
+                  <direct name="clk_to_G" input="ff.clk" output="LATCH.G"/>
+                  <direct name="Q_to_Q" input="LATCH.Q" output="ff.Q"/>
+                </interconnect>
+              </mode>
+              <mode name="LATCHN">
+                <pb_type name="LATCHN" num_pb="1" blif_model=".subckt latchn">
+                  <input  name="D" num_pins="1"/>
+                  <clock  name="G" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="LATCHN.D" clock="G"/>
+                  <T_hold  value="2.87314e-11" port="LATCHN.D" clock="G"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCHN.Q" clock="G"/>
+                </pb_type>
+                <interconnect>
+                  <direct name="D_to_D" input="ff.D" output="LATCHN.D"/>
+                  <direct name="clk_to_G" input="ff.clk" output="LATCHN.G"/>
+                  <direct name="Q_to_Q" input="LATCHN.Q" output="ff.Q"/>
                 </interconnect>
               </mode>
               <mode name="LATCHSRE">
                 <pb_type name="LATCHSRE" num_pb="1" blif_model=".subckt latchsre">
-                  <input  name="D"  num_pins="1"/>
-                  <input  name="S"  num_pins="1"/>
-                  <input  name="R"  num_pins="1"/>
-                  <input  name="E"  num_pins="1"/>
-                  <clock  name="G"  num_pins="1"/>
-                  <output name="Q"  num_pins="1"/>
-                  <T_setup      value="6.34486e-11" port="LATCHSRE.D" clock="G" />
-                  <T_hold       value="2.87314e-11" port="LATCHSRE.D" clock="G" />
-                  <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="LATCHSRE.Q" clock="G" />
-                  <T_setup      value="-6.704e-11" port="LATCHSRE.S" clock="G"/>
-                  <T_setup      value="-8.73915e-11"  port="LATCHSRE.R" clock="G"/>
-                  <T_setup      value="8.14058e-11" port="LATCHSRE.E" clock="G"/>
-                  <T_hold       value="8.85886e-11" port="LATCHSRE.S" clock="G"/>
-                  <T_hold       value="1.3408e-10"  port="LATCHSRE.R" clock="G"/>
-                  <T_hold       value="1.07743e-11" port="LATCHSRE.E" clock="G"/>
+                  <input  name="D" num_pins="1"/>
+                  <input  name="S" num_pins="1"/>
+                  <input  name="R" num_pins="1"/>
+                  <input  name="E" num_pins="1"/>
+                  <clock  name="G" num_pins="1"/>
+                  <output name="Q" num_pins="1"/>
+                  <T_setup value="6.34486e-11" port="LATCHSRE.D" clock="G"/>
+                  <T_hold  value="2.87314e-11" port="LATCHSRE.D" clock="G"/>
+                  <T_setup value="-6.704e-11" port="LATCHSRE.S" clock="G"/>
+                  <T_hold  value="8.85886e-11" port="LATCHSRE.S" clock="G"/>
+                  <T_setup value="-8.73915e-11" port="LATCHSRE.R" clock="G"/>
+                  <T_hold  value="1.3408e-10" port="LATCHSRE.R" clock="G"/>
+                  <T_setup value="8.14058e-11" port="LATCHSRE.E" clock="G"/>
+                  <T_hold  value="1.07743e-11" port="LATCHSRE.E" clock="G"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCHSRE.Q" clock="G"/>
                 </pb_type>
                 <interconnect>
-                  <direct name="D"  input="ff.D"       output="LATCHSRE.D"/>
-                  <direct name="S"  input="ff.S"       output="LATCHSRE.S"/>
-                  <direct name="R"  input="ff.R"       output="LATCHSRE.R"/>
-                  <direct name="E"  input="ff.E"       output="LATCHSRE.E"/>
-                  <direct name="C"  input="ff.clk"     output="LATCHSRE.G"/>
-                  <direct name="Q"  input="LATCHSRE.Q"  output="ff.Q"/>
+                  <direct name="D_to_D" input="ff.D" output="LATCHSRE.D"/>
+                  <direct name="S_to_S" input="ff.S" output="LATCHSRE.S"/>
+                  <direct name="R_to_R" input="ff.R" output="LATCHSRE.R"/>
+                  <direct name="E_to_E" input="ff.E" output="LATCHSRE.E"/>
+                  <direct name="clk_to_G" input="ff.clk" output="LATCHSRE.G"/>
+                  <direct name="Q_to_Q" input="LATCHSRE.Q" output="ff.Q"/>
                 </interconnect>
               </mode>
               <mode name="LATCHNSRE">
                 <pb_type name="LATCHNSRE" num_pb="1" blif_model=".subckt latchnsre">
-                  <input  name="D"  num_pins="1"/>
-                  <input  name="S"  num_pins="1"/>
-                  <input  name="R"  num_pins="1"/>
-                  <input  name="E"  num_pins="1"/>
-                  <clock  name="G"  num_pins="1"/>
-                  <output name="Q"  num_pins="1"/>
-                  <T_setup      value="6.34486e-11" port="LATCHNSRE.D" clock="G" />
-                  <T_hold       value="2.87314e-11" port="LATCHNSRE.D" clock="G" />
-                  <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="LATCHNSRE.Q" clock="G" />
-                  <T_setup      value="-6.704e-11" port="LATCHNSRE.S" clock="G"/>
-                  <T_setup      value="-8.73915e-11"  port="LATCHNSRE.R" clock="G"/>
-                  <T_setup      value="8.14058e-11" port="LATCHNSRE.E" clock="G"/>
-                  <T_hold       value="8.85886e-11" port="LATCHNSRE.S" clock="G"/>
-                  <T_hold       value="1.3408e-10"  port="LATCHNSRE.R" clock="G"/>
-                  <T_hold       value="1.07743e-11" port="LATCHNSRE.E" clock="G"/>
-                </pb_type>
-                <interconnect>
-                  <direct name="D"  input="ff.D"       output="LATCHNSRE.D"/>
-                  <direct name="S"  input="ff.S"       output="LATCHNSRE.S"/>
-                  <direct name="R"  input="ff.R"       output="LATCHNSRE.R"/>
-                  <direct name="E"  input="ff.E"       output="LATCHNSRE.E"/>
-                  <direct name="C"  input="ff.clk"     output="LATCHNSRE.G"/>
-                  <direct name="Q"  input="LATCHNSRE.Q"  output="ff.Q"/>
-                </interconnect>
-              </mode>
-              <mode name="DFFSRE">
-                <pb_type  name="DFFSRE" blif_model=".subckt dffsre" num_pb="1">
                   <input  name="D" num_pins="1"/>
                   <input  name="S" num_pins="1"/>
                   <input  name="R" num_pins="1"/>
                   <input  name="E" num_pins="1"/>
+                  <clock  name="G" num_pins="1"/>
                   <output name="Q" num_pins="1"/>
-                  <clock  name="C" num_pins="1"/>
-                  <T_setup      value="6.34486e-11" port="DFFSRE.D" clock="C"/>
-                  <T_setup      value="-6.704e-11" port="DFFSRE.S" clock="C"/>
-                  <T_setup      value="-8.73915e-11"  port="DFFSRE.R" clock="C"/>
-                  <T_setup      value="8.14058e-11" port="DFFSRE.E" clock="C"/>
-                  <T_hold       value="2.87314e-11"  port="DFFSRE.D" clock="C"/>
-                  <T_hold       value="8.85886e-11" port="DFFSRE.S" clock="C"/>
-                  <T_hold       value="1.3408e-10"  port="DFFSRE.R" clock="C"/>
-                  <T_hold       value="1.07743e-11" port="DFFSRE.E" clock="C"/>
-                  <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="DFFSRE.Q" clock="C"/>
+                  <T_setup value="6.34486e-11" port="LATCHNSRE.D" clock="G"/>
+                  <T_hold  value="2.87314e-11" port="LATCHNSRE.D" clock="G"/>
+                  <T_setup value="-6.704e-11" port="LATCHNSRE.S" clock="G"/>
+                  <T_hold  value="8.85886e-11" port="LATCHNSRE.S" clock="G"/>
+                  <T_setup value="-8.73915e-11" port="LATCHNSRE.R" clock="G"/>
+                  <T_hold  value="1.3408e-10" port="LATCHNSRE.R" clock="G"/>
+                  <T_setup value="8.14058e-11" port="LATCHNSRE.E" clock="G"/>
+                  <T_hold  value="1.07743e-11" port="LATCHNSRE.E" clock="G"/>
+                  <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCHNSRE.Q" clock="G"/>
                 </pb_type>
                 <interconnect>
-                  <direct name="D" input="ff.D"     output="DFFSRE.D"/>
-                  <direct name="C" input="ff.clk"   output="DFFSRE.C"/>
-                  <direct name="S" input="ff.S"     output="DFFSRE.S"/>
-                  <direct name="R" input="ff.R"     output="DFFSRE.R"/>
-                  <direct name="E" input="ff.E"     output="DFFSRE.E"/>
-                  <direct name="Q" input="DFFSRE.Q"  output="ff.Q"/>
+                  <direct name="D_to_D" input="ff.D" output="LATCHNSRE.D"/>
+                  <direct name="S_to_S" input="ff.S" output="LATCHNSRE.S"/>
+                  <direct name="R_to_R" input="ff.R" output="LATCHNSRE.R"/>
+                  <direct name="E_to_E" input="ff.E" output="LATCHNSRE.E"/>
+                  <direct name="clk_to_G" input="ff.clk" output="LATCHNSRE.G"/>
+                  <direct name="Q_to_Q" input="LATCHNSRE.Q" output="ff.Q"/>
                 </interconnect>
               </mode>
-              <mode name="DFFNSRE">
-                <pb_type name="DFFNSRE" blif_model=".subckt dffnsre" num_pb="1">
-                  <input  name="D" num_pins="1"/>
-                  <input  name="S" num_pins="1"/>
-                  <input  name="R" num_pins="1"/>
-                  <input  name="E" num_pins="1"/>
-                  <output name="Q" num_pins="1"/>
-                  <clock  name="C" num_pins="1"/>
-                  <T_setup      value="6.34486e-11" port="DFFNSRE.D" clock="C"/>
-                  <T_setup      value="-6.704e-11" port="DFFNSRE.S" clock="C"/>
-                  <T_setup      value="-8.73915e-11"  port="DFFNSRE.R" clock="C"/>
-                  <T_setup      value="8.14058e-11" port="DFFNSRE.E" clock="C"/>
-                  <T_hold       value="2.87314e-11"  port="DFFNSRE.D" clock="C"/>
-                  <T_hold       value="8.85886e-11" port="DFFNSRE.S" clock="C"/>
-                  <T_hold       value="1.3408e-10"  port="DFFNSRE.R" clock="C"/>
-                  <T_hold       value="1.07743e-11" port="DFFNSRE.E" clock="C"/>
-                  <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="DFFNSRE.Q" clock="C"/>
-                </pb_type>
-                <interconnect>
-                  <direct name="D" input="ff.D"     output="DFFNSRE.D"/>
-                  <direct name="C" input="ff.clk"   output="DFFNSRE.C"/>
-                  <direct name="S" input="ff.S"     output="DFFNSRE.S"/>
-                  <direct name="R" input="ff.R"     output="DFFNSRE.R"/>
-                  <direct name="E" input="ff.E"     output="DFFNSRE.E"/>
-                  <direct name="Q" input="DFFNSRE.Q"  output="ff.Q"/>
-                </interconnect>
-              </mode>
+
             </pb_type>
             <interconnect>
               <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
               <direct name="direct2" input="lut6.out" output="ff.D">
                 <pack_pattern name="lut6-out" in_port="lut6.out" out_port="ff.D"/>
-              </direct>
+             </direct>
               <direct name="direct3" input="ble6.clk" output="ff.clk"/>
               <direct name="direct4" input="ble6.set" output="ff.S"/>
               <direct name="direct5" input="ble6.reset" output="ff.R"/>
               <direct name="direct6" input="ble6.enable" output="ff.E"/>
+              <direct name="direct7" input="ble6.sync_set" output="ff.SYNC_S"/>
+              <direct name="direct8" input="ble6.sync_reset" output="ff.SYNC_R"/>
               <mux name="mux4" input="lut6.out ff.Q" output="ble6.out">
                 <delay_constant max="1.42435e-10" min="9.1011e-11" in_port="ff.Q" out_port="ble6.out"/>
                 <delay_constant max="1.48513e-10" min="1.42584e-10" in_port="lut6.out" out_port="ble6.out"/>
@@ -1582,6 +1799,8 @@
             <direct name="direct4" input="fle.set"    output="ble6.set"/>
             <direct name="direct5" input="fle.reset"  output="ble6.reset"/>
             <direct name="direct6" input="fle.enable" output="ble6.enable"/>
+            <direct name="direct7" input="fle.sync_set"    output="ble6.sync_set"/>
+            <direct name="direct8" input="fle.sync_reset"  output="ble6.sync_reset"/>
           </interconnect>
         </mode>
         <!-- Define n1_lut6 mode ends -->
@@ -1593,6 +1812,8 @@
             <input name="cin" num_pins="1"/>
             <input name="set" num_pins="1"/>
             <input name="reset" num_pins="1"/>
+            <input name="sync_set" num_pins="1"/>
+            <input name="sync_reset" num_pins="1"/>
             <input name="enable" num_pins="1"/>
             <output name="out" num_pins="2"/>
             <output name="cout" num_pins="1"/>
@@ -1602,6 +1823,8 @@
               <input name="cin" num_pins="1"/>
               <input name="set" num_pins="1"/>
               <input name="reset" num_pins="1"/>
+              <input name="sync_set" num_pins="1"/>
+              <input name="sync_reset" num_pins="1"/>
               <input name="enable" num_pins="1"/>
               <output name="out" num_pins="1"/>
               <output name="cout" num_pins="1"/>
@@ -1610,8 +1833,10 @@
                 <pb_type name="flut5" num_pb="1">
                   <input name="in" num_pins="5"/>
                   <input name="set" num_pins="1"/>
-		              <input name="reset" num_pins="1"/>
-		              <input name="enable" num_pins="1"/>
+                  <input name="reset" num_pins="1"/>
+                  <input name="sync_set" num_pins="1"/>
+                  <input name="sync_reset" num_pins="1"/>
+                  <input name="enable" num_pins="1"/>
                   <output name="out" num_pins="1"/>
                   <clock name="clk" num_pins="1"/>
                   <!-- Regular LUT mode -->
@@ -1634,138 +1859,255 @@
                         6e-11
                     </delay_matrix>
                   </pb_type>
-                  <pb_type name="ff"  num_pb="1">
+                  <pb_type name="ff" num_pb="1">
                     <input name="D" num_pins="1"/>
                     <input name="S" num_pins="1"/>
                     <input name="R" num_pins="1"/>
+                    <input name="SYNC_S" num_pins="1"/>
+                    <input name="SYNC_R" num_pins="1"/>
                     <input name="E" num_pins="1"/>
                     <output name="Q" num_pins="1"/>
        	            <clock name="clk" num_pins="1"/>
-		                <mode name="LATCH">
-		                  <pb_type name="LATCH" blif_model=".latch" num_pb="1" class="flipflop">
+
+                    <mode name="native_latch">
+                      <pb_type name="native_latch" blif_model=".latch" num_pb="1" class="flipflop">
                         <input  name="D" num_pins="1" port_class="D"/>
                         <output name="Q" num_pins="1" port_class="Q"/>
                         <clock  name="clk" num_pins="1" port_class="clock"/>
-                        <T_setup      value="6.34486e-11" port="LATCH.D" clock="clk"/>
-                        <T_hold       value="2.87314e-11" port="LATCH.D" clock="clk"/>
-                                          <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="LATCH.Q" clock="clk"/>
-		                    </pb_type>
-		                    <interconnect>
-                          <direct input="LATCH.Q" name="LATCH-Q" output="ff.Q">
-                          </direct>
-                          <direct input="ff.D" name="LATCH-D" output="LATCH.D">
-                          </direct>
-                          <direct input="ff.clk" name="LATCH-clk" output="LATCH.clk"/>
-		                    </interconnect>
-		                </mode>
-		                <mode name="LATCHSRE">
-		                  <pb_type name="LATCHSRE" num_pb="1" blif_model=".subckt latchsre">
-                        <input  name="D"  num_pins="1"/>
-                        <input  name="S"  num_pins="1"/>
-                        <input  name="R"  num_pins="1"/>
-                        <input  name="E"  num_pins="1"/>
-                        <clock  name="G"  num_pins="1"/>
-                        <output name="Q"  num_pins="1"/>
-                        <T_setup      value="6.34486e-11" port="LATCHSRE.D" clock="G" />
-                        <T_hold       value="2.87314e-11" port="LATCHSRE.D" clock="G" />
-                        <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="LATCHSRE.Q" clock="G" />
-                        <T_setup      value="-6.704e-11" port="LATCHSRE.S" clock="G"/>
-                        <T_setup      value="-8.73915e-11"  port="LATCHSRE.R" clock="G"/>
-                        <T_setup      value="8.14058e-11" port="LATCHSRE.E" clock="G"/>
-                        <T_hold       value="8.85886e-11" port="LATCHSRE.S" clock="G"/>
-                        <T_hold       value="1.3408e-10"  port="LATCHSRE.R" clock="G"/>
-                        <T_hold       value="1.07743e-11" port="LATCHSRE.E" clock="G"/>
-		                  </pb_type>
-		                  <interconnect>
-                        <direct name="D"  input="ff.D"       output="LATCHSRE.D"/>
-                        <direct name="S"  input="ff.S"       output="LATCHSRE.S"/>
-                        <direct name="R"  input="ff.R"       output="LATCHSRE.R"/>
-                        <direct name="E"  input="ff.E"       output="LATCHSRE.E"/>
-                        <direct name="C"  input="ff.clk"     output="LATCHSRE.G"/>
-                        <direct name="Q"  input="LATCHSRE.Q"  output="ff.Q"/>
-		                  </interconnect>
-		                </mode>
-                    <mode name="LATCHNSRE">
-                      <pb_type name="LATCHNSRE" num_pb="1" blif_model=".subckt latchnsre">
-                        <input  name="D"  num_pins="1"/>
-                        <input  name="S"  num_pins="1"/>
-                        <input  name="R"  num_pins="1"/>
-                        <input  name="E"  num_pins="1"/>
-                        <clock  name="G"  num_pins="1"/>
-                        <output name="Q"  num_pins="1"/>
-                        <T_setup      value="6.34486e-11" port="LATCHNSRE.D" clock="G" />
-                        <T_hold       value="2.87314e-11" port="LATCHNSRE.D" clock="G" />
-                        <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="LATCHNSRE.Q" clock="G" />
-                        <T_setup      value="-6.704e-11" port="LATCHNSRE.S" clock="G"/>
-                        <T_setup      value="-8.73915e-11"  port="LATCHNSRE.R" clock="G"/>
-                        <T_setup      value="8.14058e-11" port="LATCHNSRE.E" clock="G"/>
-                        <T_hold       value="8.85886e-11" port="LATCHNSRE.S" clock="G"/>
-                        <T_hold       value="1.3408e-10"  port="LATCHNSRE.R" clock="G"/>
-                        <T_hold       value="1.07743e-11" port="LATCHNSRE.E" clock="G"/>
+                        <T_setup value="6.34486e-11" port="native_latch.D" clock="clk"/>
+                        <T_hold  value="2.87314e-11"  port="native_latch.D" clock="clk"/>
+                        <T_clock_to_Q max="7.09448e-10" min="4.08795e-10" port="native_latch.Q" clock="clk"/>
                       </pb_type>
                       <interconnect>
-                        <direct name="D"  input="ff.D"       output="LATCHNSRE.D"/>
-                        <direct name="S"  input="ff.S"       output="LATCHNSRE.S"/>
-                        <direct name="R"  input="ff.R"       output="LATCHNSRE.R"/>
-                        <direct name="E"  input="ff.E"       output="LATCHNSRE.E"/>
-                        <direct name="C"  input="ff.clk"     output="LATCHNSRE.G"/>
-                        <direct name="Q"  input="LATCHNSRE.Q"  output="ff.Q"/>
+                        <direct  name="Q"   input="native_latch.Q" output="ff.Q"/>
+                        <direct  name="D"   input="ff.D"           output="native_latch.D"/>
+                        <direct  name="clk" input="ff.clk"         output="native_latch.clk"/>
                       </interconnect>
                     </mode>
-		                <mode name="DFFSRE">
-		                  <pb_type name="DFFSRE" blif_model=".subckt dffsre" num_pb="1">
+      
+                    <mode name="DFF">
+                      <pb_type name="DFF" num_pb="1" blif_model=".subckt dff">
+                        <input  name="D" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <clock  name="C" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="DFF.D" clock="C"/>
+                        <T_hold  value="2.87314e-11" port="DFF.D" clock="C"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFF.Q" clock="C"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="DFF.D"/>
+                        <direct name="Q_to_Q" input="DFF.Q" output="ff.Q"/>
+                        <direct name="clk_to_C" input="ff.clk" output="DFF.C"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="DFFN">
+                      <pb_type name="DFFN" num_pb="1" blif_model=".subckt dffn">
+                        <input  name="D" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <clock  name="C" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="DFFN.D" clock="C"/>
+                        <T_hold  value="2.87314e-11" port="DFFN.D" clock="C"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFFN.Q" clock="C"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="DFFN.D"/>
+                        <direct name="Q_to_Q" input="DFFN.Q" output="ff.Q"/>
+                        <direct name="clk_to_C" input="ff.clk" output="DFFN.C"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="DFFSRE">
+                      <pb_type name="DFFSRE" num_pb="1" blif_model=".subckt dffsre">
                         <input  name="D" num_pins="1"/>
                         <input  name="S" num_pins="1"/>
                         <input  name="R" num_pins="1"/>
                         <input  name="E" num_pins="1"/>
                         <output name="Q" num_pins="1"/>
                         <clock  name="C" num_pins="1"/>
-                        <T_setup      value="6.34486e-11" port="DFFSRE.D" clock="C"/>
-                        <T_setup      value="-6.704e-11" port="DFFSRE.S" clock="C"/>
-                        <T_setup      value="-8.73915e-11"  port="DFFSRE.R" clock="C"/>
-                        <T_setup      value="8.14058e-11" port="DFFSRE.E" clock="C"/>
-                        <T_hold       value="2.87314e-11"  port="DFFSRE.D" clock="C"/>
-                        <T_hold       value="8.85886e-11" port="DFFSRE.S" clock="C"/>
-                        <T_hold       value="1.3408e-10"  port="DFFSRE.R" clock="C"/>
-                        <T_hold       value="1.07743e-11" port="DFFSRE.E" clock="C"/>
-                        <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="DFFSRE.Q" clock="C"/>
-		                  </pb_type>
-		                  <interconnect>
-                        <direct name="D" input="ff.D"     output="DFFSRE.D"/>
-                        <direct name="C" input="ff.clk"   output="DFFSRE.C"/>
-                        <direct name="S" input="ff.S"     output="DFFSRE.S"/>
-                        <direct name="R" input="ff.R"     output="DFFSRE.R"/>
-                        <direct name="E" input="ff.E"     output="DFFSRE.E"/>
-                        <direct name="Q" input="DFFSRE.Q"  output="ff.Q"/>
-		                  </interconnect>
+                        <T_setup value="6.34486e-11" port="DFFSRE.D" clock="C"/>
+                        <T_hold  value="2.87314e-11" port="DFFSRE.D" clock="C"/>
+                        <T_setup value="-6.704e-11" port="DFFSRE.S" clock="C"/>
+                        <T_hold  value="8.85886e-11" port="DFFSRE.S" clock="C"/>
+                        <T_setup value="-8.73915e-11" port="DFFSRE.R" clock="C"/>
+                        <T_hold  value="1.3408e-10" port="DFFSRE.R" clock="C"/>
+                        <T_setup value="8.14058e-11" port="DFFSRE.E" clock="C"/>
+                        <T_hold  value="1.07743e-11" port="DFFSRE.E" clock="C"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFFSRE.Q" clock="C"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="DFFSRE.D"/>
+                        <direct name="S_to_S" input="ff.S" output="DFFSRE.S"/>
+                        <direct name="R_to_R" input="ff.R" output="DFFSRE.R"/>
+                        <direct name="E_to_E" input="ff.E" output="DFFSRE.E"/>
+                        <direct name="Q_to_Q" input="DFFSRE.Q" output="ff.Q"/>
+                        <direct name="clk_to_C" input="ff.clk" output="DFFSRE.C"/>
+                      </interconnect>
                     </mode>
                     <mode name="DFFNSRE">
-                      <pb_type name="DFFNSRE" blif_model=".subckt dffnsre" num_pb="1">
+                      <pb_type name="DFFNSRE" num_pb="1" blif_model=".subckt dffnsre">
                         <input  name="D" num_pins="1"/>
                         <input  name="S" num_pins="1"/>
                         <input  name="R" num_pins="1"/>
                         <input  name="E" num_pins="1"/>
                         <output name="Q" num_pins="1"/>
                         <clock  name="C" num_pins="1"/>
-                        <T_setup      value="6.34486e-11" port="DFFNSRE.D" clock="C"/>
-                        <T_setup      value="-6.704e-11" port="DFFNSRE.S" clock="C"/>
-                        <T_setup      value="-8.73915e-11"  port="DFFNSRE.R" clock="C"/>
-                        <T_setup      value="8.14058e-11" port="DFFNSRE.E" clock="C"/>
-                        <T_hold       value="2.87314e-11"  port="DFFNSRE.D" clock="C"/>
-                        <T_hold       value="8.85886e-11" port="DFFNSRE.S" clock="C"/>
-                        <T_hold       value="1.3408e-10"  port="DFFNSRE.R" clock="C"/>
-                        <T_hold       value="1.07743e-11" port="DFFNSRE.E" clock="C"/>
-                        <T_clock_to_Q max="1.2189e-10" min="1.1e-10" port="DFFNSRE.Q" clock="C"/>
+                        <T_setup value="6.34486e-11" port="DFFNSRE.D" clock="C"/>
+                        <T_hold  value="2.87314e-11" port="DFFNSRE.D" clock="C"/>
+                        <T_setup value="-6.704e-11" port="DFFNSRE.S" clock="C"/>
+                        <T_hold  value="8.85886e-11" port="DFFNSRE.S" clock="C"/>
+                        <T_setup value="-8.73915e-11" port="DFFNSRE.R" clock="C"/>
+                        <T_hold  value="1.3408e-10" port="DFFNSRE.R" clock="C"/>
+                        <T_setup value="8.14058e-11" port="DFFNSRE.E" clock="C"/>
+                        <T_hold  value="1.07743e-11" port="DFFNSRE.E" clock="C"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="DFFNSRE.Q" clock="C"/>
                       </pb_type>
                       <interconnect>
-                        <direct name="D" input="ff.D"     output="DFFNSRE.D"/>
-                        <direct name="C" input="ff.clk"   output="DFFNSRE.C"/>
-                        <direct name="S" input="ff.S"     output="DFFNSRE.S"/>
-                        <direct name="R" input="ff.R"     output="DFFNSRE.R"/>
-                        <direct name="E" input="ff.E"     output="DFFNSRE.E"/>
-                        <direct name="Q" input="DFFNSRE.Q"  output="ff.Q"/>
+                        <direct name="D_to_D" input="ff.D" output="DFFNSRE.D"/>
+                        <direct name="S_to_S" input="ff.S" output="DFFNSRE.S"/>
+                        <direct name="R_to_R" input="ff.R" output="DFFNSRE.R"/>
+                        <direct name="E_to_E" input="ff.E" output="DFFNSRE.E"/>
+                        <direct name="Q_to_Q" input="DFFNSRE.Q" output="ff.Q"/>
+                        <direct name="clk_to_C" input="ff.clk" output="DFFNSRE.C"/>
                       </interconnect>
                     </mode>
+                    <mode name="SDFFSRE">
+                      <pb_type name="SDFFSRE" num_pb="1" blif_model=".subckt sdffsre">
+                        <input  name="D" num_pins="1"/>
+                        <input  name="S" num_pins="1"/>
+                        <input  name="R" num_pins="1"/>
+                        <input  name="E" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <clock  name="C" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="SDFFSRE.D" clock="C"/>
+                        <T_hold  value="2.87314e-11" port="SDFFSRE.D" clock="C"/>
+                        <T_setup value="-6.704e-11" port="SDFFSRE.S" clock="C"/>
+                        <T_hold  value="8.85886e-11" port="SDFFSRE.S" clock="C"/>
+                        <T_setup value="-8.73915e-11" port="SDFFSRE.R" clock="C"/>
+                        <T_hold  value="1.3408e-10" port="SDFFSRE.R" clock="C"/>
+                        <T_setup value="8.14058e-11" port="SDFFSRE.E" clock="C"/>
+                        <T_hold  value="1.07743e-11" port="SDFFSRE.E" clock="C"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="SDFFSRE.Q" clock="C"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="SDFFSRE.D"/>
+                        <direct name="S_to_S" input="ff.SYNC_S" output="SDFFSRE.S"/>
+                        <direct name="R_to_R" input="ff.SYNC_R" output="SDFFSRE.R"/>
+                        <direct name="E_to_E" input="ff.E" output="SDFFSRE.E"/>
+                        <direct name="Q_to_Q" input="SDFFSRE.Q" output="ff.Q"/>
+                        <direct name="clk_to_C" input="ff.clk" output="SDFFSRE.C"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="SDFFNSRE">
+                      <pb_type name="SDFFNSRE" num_pb="1" blif_model=".subckt sdffnsre">
+                        <input  name="D" num_pins="1"/>
+                        <input  name="S" num_pins="1"/>
+                        <input  name="R" num_pins="1"/>
+                        <input  name="E" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <clock  name="C" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="SDFFNSRE.D" clock="C"/>
+                        <T_hold  value="2.87314e-11" port="SDFFNSRE.D" clock="C"/>
+                        <T_setup value="-6.704e-11" port="SDFFNSRE.S" clock="C"/>
+                        <T_hold  value="8.85886e-11" port="SDFFNSRE.S" clock="C"/>
+                        <T_setup value="-8.73915e-11" port="SDFFNSRE.R" clock="C"/>
+                        <T_hold  value="1.3408e-10" port="SDFFNSRE.R" clock="C"/>
+                        <T_setup value="8.14058e-11" port="SDFFNSRE.E" clock="C"/>
+                        <T_hold  value="1.07743e-11" port="SDFFNSRE.E" clock="C"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="SDFFNSRE.Q" clock="C"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="SDFFNSRE.D"/>
+                        <direct name="S_to_S" input="ff.SYNC_S" output="SDFFNSRE.S"/>
+                        <direct name="R_to_R" input="ff.SYNC_R" output="SDFFNSRE.R"/>
+                        <direct name="E_to_E" input="ff.E" output="SDFFNSRE.E"/>
+                        <direct name="Q_to_Q" input="SDFFNSRE.Q" output="ff.Q"/>
+                        <direct name="clk_to_C" input="ff.clk" output="SDFFNSRE.C"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="LATCH">
+                      <pb_type name="LATCH" num_pb="1" blif_model=".subckt latch">
+                        <input  name="D" num_pins="1"/>
+                        <clock  name="G" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="LATCH.D" clock="G"/>
+                        <T_hold  value="2.87314e-11" port="LATCH.D" clock="G"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCH.Q" clock="G"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="LATCH.D"/>
+                        <direct name="clk_to_G" input="ff.clk" output="LATCH.G"/>
+                        <direct name="Q_to_Q" input="LATCH.Q" output="ff.Q"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="LATCHN">
+                      <pb_type name="LATCHN" num_pb="1" blif_model=".subckt latchn">
+                        <input  name="D" num_pins="1"/>
+                        <clock  name="G" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="LATCHN.D" clock="G"/>
+                        <T_hold  value="2.87314e-11" port="LATCHN.D" clock="G"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCHN.Q" clock="G"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="LATCHN.D"/>
+                        <direct name="clk_to_G" input="ff.clk" output="LATCHN.G"/>
+                        <direct name="Q_to_Q" input="LATCHN.Q" output="ff.Q"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="LATCHSRE">
+                      <pb_type name="LATCHSRE" num_pb="1" blif_model=".subckt latchsre">
+                        <input  name="D" num_pins="1"/>
+                        <input  name="S" num_pins="1"/>
+                        <input  name="R" num_pins="1"/>
+                        <input  name="E" num_pins="1"/>
+                        <clock  name="G" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="LATCHSRE.D" clock="G"/>
+                        <T_hold  value="2.87314e-11" port="LATCHSRE.D" clock="G"/>
+                        <T_setup value="-6.704e-11" port="LATCHSRE.S" clock="G"/>
+                        <T_hold  value="8.85886e-11" port="LATCHSRE.S" clock="G"/>
+                        <T_setup value="-8.73915e-11" port="LATCHSRE.R" clock="G"/>
+                        <T_hold  value="1.3408e-10" port="LATCHSRE.R" clock="G"/>
+                        <T_setup value="8.14058e-11" port="LATCHSRE.E" clock="G"/>
+                        <T_hold  value="1.07743e-11" port="LATCHSRE.E" clock="G"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCHSRE.Q" clock="G"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="LATCHSRE.D"/>
+                        <direct name="S_to_S" input="ff.S" output="LATCHSRE.S"/>
+                        <direct name="R_to_R" input="ff.R" output="LATCHSRE.R"/>
+                        <direct name="E_to_E" input="ff.E" output="LATCHSRE.E"/>
+                        <direct name="clk_to_G" input="ff.clk" output="LATCHSRE.G"/>
+                        <direct name="Q_to_Q" input="LATCHSRE.Q" output="ff.Q"/>
+                      </interconnect>
+                    </mode>
+                    <mode name="LATCHNSRE">
+                      <pb_type name="LATCHNSRE" num_pb="1" blif_model=".subckt latchnsre">
+                        <input  name="D" num_pins="1"/>
+                        <input  name="S" num_pins="1"/>
+                        <input  name="R" num_pins="1"/>
+                        <input  name="E" num_pins="1"/>
+                        <clock  name="G" num_pins="1"/>
+                        <output name="Q" num_pins="1"/>
+                        <T_setup value="6.34486e-11" port="LATCHNSRE.D" clock="G"/>
+                        <T_hold  value="2.87314e-11" port="LATCHNSRE.D" clock="G"/>
+                        <T_setup value="-6.704e-11" port="LATCHNSRE.S" clock="G"/>
+                        <T_hold  value="8.85886e-11" port="LATCHNSRE.S" clock="G"/>
+                        <T_setup value="-8.73915e-11" port="LATCHNSRE.R" clock="G"/>
+                        <T_hold  value="1.3408e-10" port="LATCHNSRE.R" clock="G"/>
+                        <T_setup value="8.14058e-11" port="LATCHNSRE.E" clock="G"/>
+                        <T_hold  value="1.07743e-11" port="LATCHNSRE.E" clock="G"/>
+                        <T_clock_to_Q min="4.08795e-10" max="7.09448e-10" port="LATCHNSRE.Q" clock="G"/>
+                      </pb_type>
+                      <interconnect>
+                        <direct name="D_to_D" input="ff.D" output="LATCHNSRE.D"/>
+                        <direct name="S_to_S" input="ff.S" output="LATCHNSRE.S"/>
+                        <direct name="R_to_R" input="ff.R" output="LATCHNSRE.R"/>
+                        <direct name="E_to_E" input="ff.E" output="LATCHNSRE.E"/>
+                        <direct name="clk_to_G" input="ff.clk" output="LATCHNSRE.G"/>
+                        <direct name="Q_to_Q" input="LATCHNSRE.Q" output="ff.Q"/>
+                      </interconnect>
+                    </mode>
+
                   </pb_type>
                   <interconnect>
                     <direct name="direct1" input="flut5.in" output="lut5.in"/>
@@ -1776,6 +2118,8 @@
                     <direct name="direct4" input="flut5.set" output="ff.S"/>
                     <direct name="direct5" input="flut5.reset" output="ff.R"/>
                     <direct name="direct6" input="flut5.enable" output="ff.E"/>
+                    <direct name="direct7" input="flut5.sync_set" output="ff.SYNC_S"/>
+                    <direct name="direct8" input="flut5.sync_reset" output="ff.SYNC_R"/>
                     <mux name="mux5" input="lut5.out ff.Q" output="flut5.out">
                       <delay_constant max="1.42314e-10" min="1.42314e-10" in_port="ff.Q" out_port="flut5.out" />
                       <delay_constant max="1.48932e-10" min="1.4147e-10" in_port="lut5.out" out_port="flut5.out" />
@@ -1789,77 +2133,78 @@
                   <direct name="direct4" input="ble5.set" output="flut5.set"/>
                   <direct name="direct5" input="ble5.reset" output="flut5.reset"/>
                   <direct name="direct6" input="ble5.enable" output="flut5.enable"/>
+                  <direct name="direct7" input="ble5.sync_set" output="flut5.sync_set"/>
+                  <direct name="direct8" input="ble5.sync_reset" output="flut5.sync_reset"/>
                 </interconnect>
               </mode>
-
               <mode name="arithmetic">
-                <pb_type name="soft_adder" num_pb="1"> <!-- 2 4 input luts, 1 adder block, and mux part of soft_adder definition-->
+                <pb_type name="soft_adder" num_pb="1">
                   <input name="in" num_pins="4"/>
                   <input name="cin" num_pins="1"/>
                   <output name="out" num_pins="1"/>
                   <output name="cout" num_pins="1"/>
-		              <clock name="clk" num_pins="1"/>
-                  <pb_type name="adder" num_pb="1"> <!--adder includes 4 input lut-->
-                    <input name="in" num_pins="4"/> <!--means that this is the 4 input lut in this mode-->
+		  <clock name="clk" num_pins="1"/>
+		  <pb_type name="adder" num_pb="1">
+		    <input name="in" num_pins="4"/>
                     <input name="cin" num_pins="1"/>
                     <output name="out" num_pins="1"/>
                     <output name="cout" num_pins="1"/>
-                      <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut"> <!-- 2 4 input luts-->
-                        <input name="in" num_pins="4" port_class="lut_in"/>
-                        <output name="out" num_pins="1" port_class="lut_out"/>
-                          <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
-                            2.4e-10
-                            1.8e-10
-                            1.2e-10
-                            8e-11
-                          </delay_matrix>
-                          <delay_matrix type="min" in_port="lut4.in" out_port="lut4.out">
-                            2.2e-10
-                            1.6e-10
-                            1.1e-10
-                            7e-11
-                          </delay_matrix>
-                  </pb_type>
-		              <pb_type name="adder_carry" blif_model=".subckt adder_carry" num_pb="1"> <!--adder circuit here-->
-			              <input name="p" num_pins="1"/>
-                    <input name="g" num_pins="1"/>
-                    <input name="cin" num_pins="1"/>
-                    <output name="sumout" num_pins="1"/>
-                    <output name="cout" num_pins="1"/>
+		    <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+			<input name="in" num_pins="4" port_class="lut_in"/>
+			<output name="out" num_pins="1" port_class="lut_out"/>
+			<delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                          2.4e-10
+                          1.8e-10
+                          1.2e-10
+                          8e-11
+                        </delay_matrix>
+                        <delay_matrix type="min" in_port="lut4.in" out_port="lut4.out">
+                          2.2e-10
+                          1.6e-10
+                          1.1e-10
+                          7e-11
+                        </delay_matrix>
+		    </pb_type>
+		    <pb_type name="adder_carry" blif_model=".subckt adder_carry" num_pb="1">
+			<input name="p" num_pins="1"/>
+			<input name="g" num_pins="1"/>
+			<input name="cin" num_pins="1"/>
+			<output name="sumout" num_pins="1"/>
+			<output name="cout" num_pins="1"/>
                         <delay_constant max="5e-11" min="4e-11" in_port="adder_carry.p" out_port="adder_carry.sumout"/>
                         <delay_constant max="8.9626e-11" min="8.2339e-11" in_port="adder_carry.g" out_port="adder_carry.sumout"/>
                         <delay_constant max="5e-11" min="3e-11" in_port="adder_carry.cin" out_port="adder_carry.sumout"/>
                         <delay_constant max="5e-11" min="3e-11" in_port="adder_carry.p" out_port="adder_carry.cout"/>
                         <delay_constant max="5e-11" min="3e-11" in_port="adder_carry.g" out_port="adder_carry.cout"/>
                         <delay_constant max="5e-11" min="4e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
-		              </pb_type>
+		    </pb_type>
+	            <interconnect>
+			<direct name="direct2" input="adder.in[3:0]" output="lut4[0:0].in[3:0]"/>
+			<direct name="direct3" input="adder.in[3:0]" output="lut4[1:1].in[3:0]"/>
+			<direct name="direct4" input="lut4[0:0].out"    output="adder_carry.p"/>
+			<direct name="direct5" input="lut4[1:1].out"    output="adder_carry.g"/>
+			<direct name="carry_in"  input="adder.cin"     output="adder_carry.cin">
+			  <pack_pattern name="carrychain" in_port="adder.cin"  out_port="adder_carry.cin"/>
+			</direct>
+			<direct name="carry_out" input="adder_carry.cout" output="adder.cout">
+			  <pack_pattern name="carrychain" in_port="adder_carry.cout" out_port="adder.cout"/>
+			</direct>
+                        <!-- CHECK -->
+			<mux name="mux6" input="adder_carry.sumout adder_carry.cout" output="adder.out">
+                          <delay_constant max="1.51897e-10" min="1.3619e-10" in_port="adder_carry.sumout" out_port="adder.out"/>
+                          <delay_constant max="1.59941e-10" min="1.3733e-10" in_port="adder_carry.cout" out_port="adder.out" />
+			</mux>
+		    </interconnect>
+		  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input  name="D"   num_pins="1" port_class="D"/>
+                    <output name="Q"   num_pins="1" port_class="Q"/>
+                    <clock  name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup      value="6.34486e-11"  port="ff.D"   clock="clk"/>
+                    <T_hold       value="2.87314e-11"  port="ff.D"   clock="clk"/>
+                    <T_clock_to_Q max="7.09448e-10"  min="4.08795e-10" port="ff.Q"   clock="clk"/>
+                  </pb_type>
                   <interconnect>
-                    <direct name="direct2" input="adder.in[3:0]" output="lut4[0:0].in[3:0]"/>
-                    <direct name="direct3" input="adder.in[3:0]" output="lut4[1:1].in[3:0]"/>
-                    <direct name="direct4" input="lut4[0:0].out"    output="adder_carry.p"/>
-                    <direct name="direct5" input="lut4[1:1].out"    output="adder_carry.g"/>
-                    <direct name="carry_in"  input="adder.cin"     output="adder_carry.cin">
-                      <pack_pattern name="carrychain" in_port="adder.cin"  out_port="adder_carry.cin"/>
-                    </direct>
-                    <direct name="carry_out" input="adder_carry.cout" output="adder.cout">
-                      <pack_pattern name="carrychain" in_port="adder_carry.cout" out_port="adder.cout"/>
-                    </direct>
-                            <!-- CHECK --> <!--soft_adder pb_type includes the mux leading to the flip flop, not actually a 2 mux here but it is modelled as a 2 input mux because only 2 inputs are used in this mode-->
-                    <mux name="mux6" input="adder_carry.sumout adder_carry.cout" output="adder.out">
-                                        <delay_constant max="1.51897e-10" min="1.3619e-10" in_port="adder_carry.sumout" out_port="adder.out"/>
-                                        <delay_constant max="1.59941e-10" min="1.3733e-10" in_port="adder_carry.cout" out_port="adder.out" />
-                    </mux>
-                  </interconnect>
-		            </pb_type> <!--end of arithmetic soft adder pb_type-->
-                <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop"> <!--ff part of arithmetic mode-->
-                  <input  name="D"   num_pins="1" port_class="D"/>
-                  <output name="Q"   num_pins="1" port_class="Q"/>
-                  <clock  name="clk" num_pins="1" port_class="clock"/>
-                  <T_setup      value="6.34486e-11"  port="ff.D"   clock="clk"/>
-                  <T_hold       value="2.87314e-11"  port="ff.D"   clock="clk"/>
-                  <T_clock_to_Q max="1.2189e-10"  min="1.1e-10" port="ff.Q"   clock="clk"/>
-                </pb_type>
-                  <interconnect> <!--direct connections can be infered through muxes based on physical mode-->
                     <direct name="direct1" input="soft_adder.clk" output="ff.clk"/>
                     <direct name="direct2" input="soft_adder.in" output="adder.in"/>
                     <direct name="add_to_ff"   input="adder.out"       output="ff.D">
@@ -1871,7 +2216,7 @@
                     <direct name="carry_out"   input="adder.cout"         output="soft_adder.cout">
                       <pack_pattern name="carrychain" in_port="adder.cout"      out_port="soft_adder.cout"/>
                     </direct>
-                    <mux name="mux7" input="adder.out ff.Q" output="soft_adder.out"> <!--this is the final fux in FLE-->
+                    <mux name="mux7" input="adder.out ff.Q" output="soft_adder.out">
                       <delay_constant max="9.6311e-11" min="8.3582e-11" in_port="adder.out" out_port="soft_adder.out"/>
                       <delay_constant max="1.42314e-10" min="8.9674e-11" in_port="ff.Q"         out_port="soft_adder.out" />
                     </mux>
@@ -1886,7 +2231,7 @@
                   </direct>
                   <direct name="direct5" input="ble5.clk" output="soft_adder.clk"/>
                 </interconnect>
-              </mode> <!--end of arithmetic mode-->
+              </mode>
             </pb_type>
             <interconnect>
               <direct name="direct1"     input="lut5inter.in"     output="ble5[0:0].in"/>
@@ -1902,6 +2247,8 @@
               </direct>
               <complete name="set"       input="lut5inter.set"    output="ble5[1:0].set"/>
               <complete name="reset"     input="lut5inter.reset"  output="ble5[1:0].reset"/>
+              <complete name="sync_set"       input="lut5inter.sync_set"    output="ble5[1:0].sync_set"/>
+              <complete name="sync_reset"     input="lut5inter.sync_reset"  output="ble5[1:0].sync_reset"/>
               <complete name="enable"    input="lut5inter.enable" output="ble5[1:0].enable"/>
               <complete name="complete1" input="lut5inter.clk"    output="ble5[1:0].clk"/>
             </interconnect>
@@ -1917,6 +2264,8 @@
 	    <direct name="set"    input="fle.set"    output="lut5inter.set"/>
 	    <direct name="reset"  input="fle.reset"  output="lut5inter.reset"/>
 	    <direct name="enable" input="fle.enable" output="lut5inter.enable"/>
+	    <direct name="sync_set"    input="fle.sync_set"    output="lut5inter.sync_set"/>
+	    <direct name="sync_reset"  input="fle.sync_reset"  output="lut5inter.sync_reset"/>
           </interconnect>
         </mode>
         <!-- Define n2_lut5 mode ends -->
@@ -1938,7 +2287,7 @@
                   <clock name="C" num_pins="1"/>
                   <T_setup value="6.34486e-11" port="DFF.D" clock="C"/>
                   <T_hold value="2.87314e-11" port="DFF.D" clock="C"/>
-                  <T_clock_to_Q max="1.2189e-10" port="DFF.Q" clock="C"/>
+                  <T_clock_to_Q max="7.09448e-10" port="DFF.Q" clock="C"/>
                 </pb_type>
                 <interconnect>
                   <direct input="DFF.Q" name="FF-Q" output="ff.Q">
@@ -1984,25 +2333,25 @@
       </pb_type>
       <interconnect>
         <complete name="crossbar0" input="clb.I0 clb.I3 fle[1:0].out fle[3:2].out fle[8:8].out" output="fle[9:0].in[0]">
-          <delay_constant max="3.2e-10" min="2.2e-10" in_port="clb.I0 clb.I3" out_port="fle[9:0].in[0]" />
-          <delay_constant max="3.3e-10" min="2.6e-10" in_port="fle[1:0].out fle[3:2].out fle[8:8].out"  out_port="fle[9:0].in[0]" />
+          <delay_constant max="2.08e-10" min="1.43e-10" in_port="clb.I0 clb.I3" out_port="fle[9:0].in[0]" />
+          <delay_constant max="2.14e-10" min="1.69e-10" in_port="fle[1:0].out fle[3:2].out fle[8:8].out"  out_port="fle[9:0].in[0]" />
         </complete>
         <complete name="crossbar1" input="clb.I1 clb.I2 fle[3:2].out fle[5:4].out fle[9:9].out" output="fle[9:0].in[1]">
-          <delay_constant max="3.2e-10" min="2.2e-10" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]" />
-          <delay_constant max="3.3e-10" min="2.6e-10" in_port="fle[3:2].out fle[5:4].out fle[9:9].out"  out_port="fle[9:0].in[1]" />
+          <delay_constant max="2.08e-10" min="1.43e-10" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[1]" />
+          <delay_constant max="2.14e-10" min="1.69e-10" in_port="fle[3:2].out fle[5:4].out fle[9:9].out"  out_port="fle[9:0].in[1]" />
         </complete>
         <complete name="crossbar2" input="clb.I0 clb.I2 fle[5:4].out fle[7:6].out fle[8:8].out" output="fle[9:0].in[2]">
-          <delay_constant max="3.2e-10" min="2.2e-10" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[2]" />
-          <delay_constant max="3.3e-10" min="2.6e-10" in_port="fle[5:4].out fle[7:6].out fle[8:8].out"  out_port="fle[9:0].in[2]" />
+          <delay_constant max="2.08e-10" min="1.43e-10" in_port="clb.I0 clb.I2" out_port="fle[9:0].in[2]" />
+          <delay_constant max="2.14e-10" min="1.69e-10" in_port="fle[5:4].out fle[7:6].out fle[8:8].out"  out_port="fle[9:0].in[2]" />
         </complete>
         <complete name="crossbar3" input="clb.I1 clb.I3" output="fle[9:0].in[3]">
-          <delay_constant max="3.2e-10" min="2.2e-10" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]" />
+          <delay_constant max="2.08e-10" min="1.43e-10" in_port="clb.I1 clb.I3" out_port="fle[9:0].in[3]" />
         </complete>
         <complete name="crossbar4" input="clb.I0 clb.I3" output="fle[9:0].in[4]">
-          <delay_constant max="3.2e-10" min="2.2e-10" in_port="clb.I0 clb.I3" out_port="fle[9:0].in[4]" />
+          <delay_constant max="2.08e-10" min="1.43e-10" in_port="clb.I0 clb.I3" out_port="fle[9:0].in[4]" />
         </complete>
         <complete name="crossbar5" input="clb.I1 clb.I2" output="fle[9:0].in[5]">
-          <delay_constant max="3.2e-10" min="2.2e-10" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[5]" />
+          <delay_constant max="2.08e-10" min="1.43e-10" in_port="clb.I1 clb.I2" out_port="fle[9:0].in[5]" />
         </complete>
         <complete name="clks"     input="clb.clk"                       output="fle[9:0].clk">
           <delay_constant max="2e-09" min="2e-09" in_port="clb.clk[0]" out_port="fle[9:0].clk"/>
@@ -2015,6 +2364,12 @@
         </complete>
         <complete name="reset"    input="clb.lreset"                     output="fle[9:0].reset">
           <delay_constant max="2.0094e-11" min="2.0079e-11" in_port="clb.lreset" out_port="fle[9:0].reset"/>
+        </complete>
+        <complete name="sync_set"      input="clb.sync_set"                       output="fle[9:0].sync_set">
+          <delay_constant max="2.0094e-11" min="2.0079e-11" in_port="clb.sync_set" out_port="fle[9:0].sync_set"/>
+        </complete>
+        <complete name="sync_reset"    input="clb.sync_reset"                     output="fle[9:0].sync_reset">
+          <delay_constant max="2.0094e-11" min="2.0079e-11" in_port="clb.sync_reset" out_port="fle[9:0].sync_reset"/>
         </complete>
         <complete name="enable"   input="clb.enable"                    output="fle[9:0].enable">
           <delay_constant max="1.53965e-10" min="3.8311e-11" in_port="clb.enable" out_port="fle[9:0].enable"/>
@@ -2219,8 +2574,10 @@
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
+          <input  name="feedback" num_pins="3"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <delay_constant max="2e-10" min="2e-10" in_port="RS_DSP2_MULT.a" out_port="RS_DSP2_MULT.z"/>
           <delay_constant max="2e-10" min="2e-10" in_port="RS_DSP2_MULT.b" out_port="RS_DSP2_MULT.z"/>
@@ -2234,6 +2591,8 @@
           <direct name="direct6" input="dsp.f_mode" output="RS_DSP2_MULT.f_mode"/>
           <direct name="direct7" input="dsp.output_select" output="RS_DSP2_MULT.output_select"/>
           <direct name="direct8" input="dsp.register_inputs" output="RS_DSP2_MULT.register_inputs"/>
+          <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULT.feedback"/>
+          <direct name="direct10" input="dsp.lreset" output="RS_DSP2_MULT.reset"/>
         </interconnect>
       </mode>
       <mode name="MULT_REGIN" disable_packing="false">
@@ -2243,12 +2602,15 @@
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
+          <input  name="feedback" num_pins="3"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN.b" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN.feedback" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULT_REGIN.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2260,6 +2622,8 @@
           <direct name="direct6" input="dsp.f_mode" output="RS_DSP2_MULT_REGIN.f_mode"/>
           <direct name="direct7" input="dsp.output_select" output="RS_DSP2_MULT_REGIN.output_select"/>
           <direct name="direct8" input="dsp.register_inputs" output="RS_DSP2_MULT_REGIN.register_inputs"/>
+          <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULT_REGIN.feedback"/>
+          <direct name="direct10" input="dsp.lreset" output="RS_DSP2_MULT_REGIN.reset"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULT_REGIN.clk"/>
         </interconnect>
       </mode>
@@ -2270,12 +2634,15 @@
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
+          <input  name="feedback" num_pins="3"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGOUT.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGOUT.b" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULT_REGOUT.feedback" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULT_REGOUT.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2287,6 +2654,8 @@
           <direct name="direct6" input="dsp.f_mode" output="RS_DSP2_MULT_REGOUT.f_mode"/>
           <direct name="direct7" input="dsp.output_select" output="RS_DSP2_MULT_REGOUT.output_select"/>
           <direct name="direct8" input="dsp.register_inputs" output="RS_DSP2_MULT_REGOUT.register_inputs"/>
+          <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULT_REGOUT.feedback"/>
+          <direct name="direct10" input="dsp.lreset" output="RS_DSP2_MULT_REGOUT.reset"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULT_REGOUT.clk"/>
         </interconnect>
       </mode>
@@ -2297,12 +2666,15 @@
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
+          <input  name="feedback" num_pins="3"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN_REGOUT.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN_REGOUT.b" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN_REGOUT.feedback" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULT_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULT_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULT_REGIN_REGOUT.a" clock="clk"/>
@@ -2319,6 +2691,8 @@
           <direct name="direct6" input="dsp.f_mode" output="RS_DSP2_MULT_REGIN_REGOUT.f_mode"/>
           <direct name="direct7" input="dsp.output_select" output="RS_DSP2_MULT_REGIN_REGOUT.output_select"/>
           <direct name="direct8" input="dsp.register_inputs" output="RS_DSP2_MULT_REGIN_REGOUT.register_inputs"/>
+          <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULT_REGIN_REGOUT.feedback"/>
+          <direct name="direct10" input="dsp.lreset" output="RS_DSP2_MULT_REGIN_REGOUT.reset"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULT_REGIN_REGOUT.clk"/>
         </interconnect>
       </mode>
@@ -2327,15 +2701,23 @@
           <input  name="a" num_pins="20"/>
           <input  name="b" num_pins="18"/>
           <input  name="subtract" num_pins="1"/>
+          <input  name="load_acc" num_pins="1"/>
+          <input  name="acc_fir" num_pins="6"/>
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
+          <input  name="feedback" num_pins="3"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <delay_constant max="2e-10" min="2e-10" in_port="RS_DSP2_MULTADD.a" out_port="RS_DSP2_MULTADD.z"/>
           <delay_constant max="2e-10" min="2e-10" in_port="RS_DSP2_MULTADD.b" out_port="RS_DSP2_MULTADD.z"/>
           <delay_constant max="2e-10" min="2e-10" in_port="RS_DSP2_MULTADD.subtract" out_port="RS_DSP2_MULTADD.z"/>
+          <delay_constant max="2e-10" min="2e-10" in_port="RS_DSP2_MULTADD.acc_fir" out_port="RS_DSP2_MULTADD.z"/>
         </pb_type>
         <interconnect>
           <direct name="direct1" input="dsp.a_i" output="RS_DSP2_MULTADD.a"/>
@@ -2347,6 +2729,13 @@
           <direct name="direct7" input="dsp.output_select" output="RS_DSP2_MULTADD.output_select"/>
           <direct name="direct8" input="dsp.register_inputs" output="RS_DSP2_MULTADD.register_inputs"/>
           <direct name="direct9" input="dsp.subtract" output="RS_DSP2_MULTADD.subtract"/>
+          <direct name="direct10" input="dsp.acc_fir_i" output="RS_DSP2_MULTADD.acc_fir"/>
+          <direct name="direct11" input="dsp.feedback" output="RS_DSP2_MULTADD.feedback"/>
+          <direct name="direct12" input="dsp.load_acc" output="RS_DSP2_MULTADD.load_acc"/>
+          <direct name="direct13" input="dsp.lreset" output="RS_DSP2_MULTADD.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTADD.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTADD.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTADD.round"/>
         </interconnect>
       </mode>
       <mode name="MULTADD_REGIN" disable_packing="false">
@@ -2356,18 +2745,24 @@
           <input  name="feedback" num_pins="3"/>
           <input  name="subtract" num_pins="1"/>
           <input  name="load_acc" num_pins="1"/>
+          <input  name="acc_fir" num_pins="6"/>
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN.b" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN.subtract" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN.feedback" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN.load_acc" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN.acc_fir" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGIN.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2382,6 +2777,11 @@
           <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULTADD_REGIN.feedback"/>
           <direct name="direct10" input="dsp.subtract" output="RS_DSP2_MULTADD_REGIN.subtract"/>
           <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTADD_REGIN.load_acc"/>
+          <direct name="direct12" input="dsp.acc_fir_i" output="RS_DSP2_MULTADD_REGIN.acc_fir"/>
+          <direct name="direct13" input="dsp.lreset" output="RS_DSP2_MULTADD_REGIN.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTADD_REGIN.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTADD_REGIN.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTADD_REGIN.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTADD_REGIN.clk"/>
         </interconnect>
       </mode>
@@ -2392,18 +2792,24 @@
           <input  name="feedback" num_pins="3"/>
           <input  name="subtract" num_pins="1"/>
           <input  name="load_acc" num_pins="1"/>
+          <input  name="acc_fir" num_pins="6"/>
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGOUT.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGOUT.b" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGOUT.subtract" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGOUT.feedback" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGOUT.load_acc" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGOUT.acc_fir" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGOUT.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2418,6 +2824,11 @@
           <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULTADD_REGOUT.feedback"/>
           <direct name="direct10" input="dsp.subtract" output="RS_DSP2_MULTADD_REGOUT.subtract"/>
           <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTADD_REGOUT.load_acc"/>
+          <direct name="direct12" input="dsp.acc_fir_i" output="RS_DSP2_MULTADD_REGOUT.acc_fir"/>
+          <direct name="direct13" input="dsp.lreset" output="RS_DSP2_MULTADD_REGOUT.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTADD_REGOUT.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTADD_REGOUT.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTADD_REGOUT.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTADD_REGOUT.clk"/>
         </interconnect>
       </mode>
@@ -2428,26 +2839,34 @@
           <input  name="feedback" num_pins="3"/>
           <input  name="subtract" num_pins="1"/>
           <input  name="load_acc" num_pins="1"/>
+          <input  name="acc_fir" num_pins="6"/>
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.b" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.subtract" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.feedback" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.load_acc" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.acc_fir" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTADD_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGIN_REGOUT.a" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGIN_REGOUT.b" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGIN_REGOUT.subtract" clock="clk"/>
+          <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTADD_REGIN_REGOUT.acc_fir" clock="clk"/>
           <delay_constant max="2e-10" in_port="RS_DSP2_MULTADD_REGIN_REGOUT.a" out_port="RS_DSP2_MULTADD_REGIN_REGOUT.z"/>
           <delay_constant max="2e-10" in_port="RS_DSP2_MULTADD_REGIN_REGOUT.b" out_port="RS_DSP2_MULTADD_REGIN_REGOUT.z"/>
           <delay_constant max="2e-10" in_port="RS_DSP2_MULTADD_REGIN_REGOUT.subtract" out_port="RS_DSP2_MULTADD_REGIN_REGOUT.z"/>
+          <delay_constant max="2e-10" in_port="RS_DSP2_MULTADD_REGIN_REGOUT.acc_fir" out_port="RS_DSP2_MULTADD_REGIN_REGOUT.z"/>
         </pb_type>
         <interconnect>
           <direct name="direct1" input="dsp.a_i" output="RS_DSP2_MULTADD_REGIN_REGOUT.a"/>
@@ -2461,6 +2880,11 @@
           <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULTADD_REGIN_REGOUT.feedback"/>
           <direct name="direct10" input="dsp.subtract" output="RS_DSP2_MULTADD_REGIN_REGOUT.subtract"/>
           <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTADD_REGIN_REGOUT.load_acc"/>
+          <direct name="direct12" input="dsp.acc_fir_i" output="RS_DSP2_MULTADD_REGIN_REGOUT.acc_fir"/>
+          <direct name="direct13" input="dsp.lreset" output="RS_DSP2_MULTADD_REGIN_REGOUT.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTADD_REGIN_REGOUT.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTADD_REGIN_REGOUT.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTADD_REGIN_REGOUT.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTADD_REGIN_REGOUT.clk"/>
         </interconnect>
       </mode>
@@ -2470,17 +2894,23 @@
           <input  name="b" num_pins="18"/>
           <input  name="feedback" num_pins="3"/>
           <input  name="subtract" num_pins="1"/>
+          <input  name="load_acc" num_pins="1"/>
           <input  name="unsigned_a" num_pins="1"/>
           <input  name="unsigned_b" num_pins="1"/>
           <input  name="f_mode" num_pins="1"/>
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC.b" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC.feedback" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC.subtract" clock="clk"/>
+          <T_setup value="2e-10"     port="RS_DSP2_MULTACC.load_acc" clock="clk"/>
           <T_clock_to_Q max="2e-10"  port="RS_DSP2_MULTACC.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2494,6 +2924,11 @@
           <direct name="direct8" input="dsp.register_inputs" output="RS_DSP2_MULTACC.register_inputs"/>
           <direct name="direct9" input="dsp.subtract" output="RS_DSP2_MULTACC.subtract"/>
           <direct name="direct10" input="dsp.feedback" output="RS_DSP2_MULTACC.feedback"/>
+          <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTACC.load_acc"/>
+          <direct name="direct12" input="dsp.lreset" output="RS_DSP2_MULTACC.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTACC.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTACC.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTACC.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTACC.clk"/>
         </interconnect>
       </mode>
@@ -2510,6 +2945,10 @@
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC_REGIN.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC_REGIN.b" clock="clk"/>
@@ -2530,6 +2969,10 @@
           <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULTACC_REGIN.feedback"/>
           <direct name="direct10" input="dsp.subtract" output="RS_DSP2_MULTACC_REGIN.subtract"/>
           <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTACC_REGIN.load_acc"/>
+          <direct name="direct12" input="dsp.lreset" output="RS_DSP2_MULTACC_REGIN.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTACC_REGIN.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTACC_REGIN.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTACC_REGIN.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTACC_REGIN.clk"/>
         </interconnect>
       </mode>
@@ -2546,6 +2989,10 @@
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC_REGOUT.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC_REGOUT.b" clock="clk"/>
@@ -2566,6 +3013,10 @@
           <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULTACC_REGOUT.feedback"/>
           <direct name="direct10" input="dsp.subtract" output="RS_DSP2_MULTACC_REGOUT.subtract"/>
           <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTACC_REGOUT.load_acc"/>
+          <direct name="direct12" input="dsp.lreset" output="RS_DSP2_MULTACC_REGOUT.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTACC_REGOUT.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTACC_REGOUT.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTACC_REGOUT.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTACC_REGOUT.clk"/>
         </interconnect>
       </mode>
@@ -2582,6 +3033,10 @@
           <input  name="output_select" num_pins="3"/>
           <input  name="register_inputs" num_pins="1"/>
           <clock  name="clk" num_pins="1"/>
+          <input  name="reset" num_pins="1"/>
+          <input  name="saturate_enable" num_pins="1"/>
+          <input  name="shift_right" num_pins="6"/>
+          <input  name="round" num_pins="1"/>
           <output  name="z" num_pins="38"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC_REGIN_REGOUT.a" clock="clk"/>
           <T_setup value="2e-10"     port="RS_DSP2_MULTACC_REGIN_REGOUT.b" clock="clk"/>
@@ -2602,6 +3057,10 @@
           <direct name="direct9" input="dsp.feedback" output="RS_DSP2_MULTACC_REGIN_REGOUT.feedback"/>
           <direct name="direct10" input="dsp.subtract" output="RS_DSP2_MULTACC_REGIN_REGOUT.subtract"/>
           <direct name="direct11" input="dsp.load_acc" output="RS_DSP2_MULTACC_REGIN_REGOUT.load_acc"/>
+          <direct name="direct12" input="dsp.lreset" output="RS_DSP2_MULTACC_REGIN_REGOUT.reset"/>
+          <direct name="direct14" input="dsp.saturate_enable" output="RS_DSP2_MULTACC_REGIN_REGOUT.saturate_enable"/>
+          <direct name="direct15" input="dsp.shift_right" output="RS_DSP2_MULTACC_REGIN_REGOUT.shift_right"/>
+          <direct name="direct16" input="dsp.round" output="RS_DSP2_MULTACC_REGIN_REGOUT.round"/>
           <complete name="clk" input="dsp.clk" output="RS_DSP2_MULTACC_REGIN_REGOUT.clk"/>
         </interconnect>
       </mode>
@@ -2898,8 +3357,7 @@
     </pb_type>
   </complexblocklist>
   <layout tileable="true" through_channel="true">
-
-     <fixed_layout name="78x66" width="80" height="68">
+    <fixed_layout name="78x66" width="80" height="68">
       <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
       <row type="io_top" starty="H-1" priority="100"/>
       <row type="io_bottom" starty="0" priority="100"/>
@@ -2936,8 +3394,5 @@
       <col type="bram" startx="66" starty="1" priority="40"/>
       <col type="bram" startx="72" starty="1" priority="40"/>
     </fixed_layout>
-
-
-
   </layout> 
 </architecture>


### PR DESCRIPTION
Update gemini_vpr.xml file with latest drop from HW/IP team (6129cf6f9b5bc12f93b90e9ed9d4ffcb7d46b59a)
This drop contains fix of missing ports in DSP modeling (based on fix from QL); and new timing of homogeniours arch (CLB) released in v1.0; and routing mux and intra-clb xbar new timing provided by PE.