### PR TITLE
Litex_rs submodule disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (NOT APPLE) # Currently OpenFPGA doesn't build on MacOS
     add_subdirectory(OpenFPGA_RS)
 endif()
 
-add_subdirectory(litex_rs)
+#add_subdirectory(litex_rs)
 
 # Raptor version
 set(VERSION_MAJOR 0)


### PR DESCRIPTION
Litex submodule disabled as it has some installation issues on root. Secondly, as a lot of things are evolving in Litex_Rs and IP catalog, this will be updated as soon as we have a stable version.