### PR TITLE
Update placement json settings for pin assignment in raptor

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -217,11 +217,26 @@
             }
         },
         "Placement": {
+            "pin_selection_radiobtn": {
+                "label": "Pin Location Assign Method:",
+                "widgetType": "radiobuttons",
+                "options": [
+                    "Random",
+                    "In Define Order"
+                ],
+                "optionsLookup":[
+                    "random",
+                    "in_define_order"
+                ],
+                "layout": "horizontal",
+                "arg": "pin_assign_method"
+            },
             "_META_": {
-                "hidden": true,
-                "isSetting": true
-            }
-        },
+                "hidden": false,
+                "isSetting": true,
+                "tclArgKey": "Tasks_placement"
+                }
+            },
         "Routing": {
             "_META_": {
                 "hidden": true,


### PR DESCRIPTION
For pin location assignment settings, following json settings for placement task dialog is added in settings_test.json file.
>- Random
>- In Define Order

This changes are addressing this issue ->   https://github.com/os-fpga/FOEDAG/pull/571#event-7207326233