### PR TITLE
Freed disk space in CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,6 +236,10 @@ jobs:
         name: buildqt5-centos7-gcc
         path: buildqt5-centos7-gcc.tgz
 
+    - name: Remove QT tar file.
+      run: |
+        rm -rf buildqt5-centos7-gcc.tgz
+
     - name: Show shell configuration
       run: |
         env


### PR DESCRIPTION
This change fixes [JIRA-336](https://rapidsilicon.atlassian.net/browse/GEMINIEDA-336)
After uploading the artifact the tar file was not removed, with this change we remove the unnecessary file and free disk space.