### PR TITLE
Raptor Window Title updated

### DIFF
--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -15,39 +15,39 @@
 namespace RS {
 
 #define Company "Rapid Silicon"
-#define ToolName "Raptor"
+#define ToolName "Raptor Design Suite"
 #define ExecutableName "raptor"
 
-QWidget* mainWindowBuilder(FOEDAG::Session* session) {
-  FOEDAG::MainWindow* mainW = new FOEDAG::MainWindow{session};
+QWidget *mainWindowBuilder(FOEDAG::Session *session) {
+  FOEDAG::MainWindow *mainW = new FOEDAG::MainWindow{session};
   auto info = mainW->Info();
-  info.name = QString("%1 %2").arg(Company, ToolName);
+  info.name = QString("%1").arg(ToolName);
   info.url = "https://github.com/RapidSilicon/Raptor/commit/";
   mainW->Info(info);
   return mainW;
 }
 
-void registerAllCommands(QWidget* widget, FOEDAG::Session* session) {
+void registerAllCommands(QWidget *widget, FOEDAG::Session *session) {
   registerAllFoedagCommands(widget, session);
 }
 
 }  // namespace RS
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   Q_INIT_RESOURCE(main_window_resource);
-  FOEDAG::CommandLine* cmd = new FOEDAG::CommandLine(argc, argv);
+  FOEDAG::CommandLine *cmd = new FOEDAG::CommandLine(argc, argv);
   cmd->processArgs();
 
   FOEDAG::GUI_TYPE guiType =
       FOEDAG::Foedag::getGuiType(cmd->WithQt(), cmd->WithQml());
 
-  FOEDAG::ToolContext* context =
+  FOEDAG::ToolContext *context =
       new FOEDAG::ToolContext(ToolName, Company, ExecutableName);
 
-  FOEDAG::Settings* settings = new FOEDAG::Settings();
+  FOEDAG::Settings *settings = new FOEDAG::Settings();
 
-  FOEDAG::Compiler* compiler = nullptr;
-  FOEDAG::CompilerRS* opcompiler = nullptr;
+  FOEDAG::Compiler *compiler = nullptr;
+  FOEDAG::CompilerRS *opcompiler = nullptr;
   if (cmd->CompilerName() == "dummy") {
     compiler = new FOEDAG::Compiler();
   } else {
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
     compiler->SetUseVerific(true);
   }
 
-  FOEDAG::Foedag* foedag =
+  FOEDAG::Foedag *foedag =
       new FOEDAG::Foedag(cmd, RS::mainWindowBuilder, RS::registerAllCommands,
                          compiler, settings, context);
   if (opcompiler) {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <[issue id]>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
Raptor's Main Window title was showed in this pattern:  "Rapid Silicon Raptor - current opened file path".

> #### What is currently done? (Provide issue link if applicable)
Now main window title is changed to following consistent pattern when any design file open in an editor:  "current-file-open-in-editor" - "project-name" - Raptor Design Suite.
>
> #### What does this pull request change?
It will change the title pattern of main window. 
