### PR TITLE
Raptor's Window Title updated with code format

### DIFF
--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -15,13 +15,13 @@
 namespace RS {
 
 #define Company "Rapid Silicon"
-#define ToolName "Raptor"
+#define ToolName "Raptor Design Suite"
 #define ExecutableName "raptor"
 
 QWidget* mainWindowBuilder(FOEDAG::Session* session) {
   FOEDAG::MainWindow* mainW = new FOEDAG::MainWindow{session};
   auto info = mainW->Info();
-  info.name = QString("%1 %2").arg(Company, ToolName);
+  info.name = QString("%1").arg(ToolName);
   info.url = "https://github.com/RapidSilicon/Raptor/commit/";
   mainW->Info(info);
   return mainW;


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <[issue id]>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
Raptor's Main Window title was showed in this pattern:  "Rapid Silicon Raptor - current opened file path".

> #### What is currently done? (Provide issue link if applicable)
Now main window title is changed to following consistent pattern when any design file open in an editor:  "current-file-open-in-editor" - "project-name" - Raptor Design Suite.
>
> #### What does this pull request change?
It will change the title pattern of main window. 
