### PR TITLE
[RG-75] Hyperlink remove from about dialog

### DIFF
--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -22,7 +22,7 @@ QWidget* mainWindowBuilder(FOEDAG::Session* session) {
   FOEDAG::MainWindow* mainW = new FOEDAG::MainWindow{session};
   auto info = mainW->Info();
   info.name = QString("%1").arg(ToolName);
-  info.url = "https://github.com/RapidSilicon/Raptor/commit/";
+  info.url.clear();
   mainW->Info(info);
   return mainW;
 }


### PR DESCRIPTION
**Motivation of Pull Request**
Remove commit hyperlink from Raptor's about dialog

**What is currently done?**
Hyperlink is removed from the about Dialog. 
Screenshot:
**Before:**
![image](https://user-images.githubusercontent.com/109368108/191024516-e92365e5-4fa5-4ef2-98c9-b45b4bc241d4.png)

**After**
![image](https://user-images.githubusercontent.com/109368108/191024686-6e668a51-cac4-4135-aff1-948a1eba470d.png)

