### PR TITLE
[GEMINIEDA-481] Replace absolute with relative path in AES_DECRYPT example

### DIFF
--- a/examples/AES_DECRYPT/AES_DECRYPT.ospr
+++ b/examples/AES_DECRYPT/AES_DECRYPT.ospr
@@ -44,7 +44,7 @@
             <File Path="$OSRCDIR/AES_DECRYPT.srcs/sources_1/generic_muxfx.v"/>
             <File Path="$OSRCDIR/AES_DECRYPT.srcs/sources_1/wrapper.v"/>
             <Group Id="11" Name="unit_0" Files="$OSRCDIR/AES_DECRYPT.srcs/sources_1/aes_decrypt128.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/aes_decrypt256.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/gfmul.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/InvMixCol_slice.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/InvSbox.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/InvSubBytes.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/KeyExpand192.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/KschBuffer.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/Sbox.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/aes_decrypt192.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/decrypt.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/InvAddRoundKey.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/InvMixColumns.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/InvShiftRows.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/KeyExpand128.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/KeyExpand256.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/RotWord.sv $OSRCDIR/AES_DECRYPT.srcs/sources_1/SubWord.sv" LibCommand="" LibName=""/>
-            <Group Id="7" Name="unit_1" Files="/home/work/Work/Raptor/tests/Testcases/aes_decrypt_fpga/generic_muxfx.v /home/work/Work/Raptor/tests/Testcases/aes_decrypt_fpga/wrapper.v" LibCommand="" LibName=""/>
+            <Group Id="7" Name="unit_1" Files="$OSRCDIR/AES_DECRYPT.srcs/sources_1/generic_muxfx.v $OSRCDIR/AES_DECRYPT.srcs/sources_1/wrapper.v" LibCommand="" LibName=""/>
             <Config>
                 <Option Name="TopModule" Val="wrapper"/>
                 <Option Name="TopModuleLib" Val=""/>


### PR DESCRIPTION
This PR replaced accidentally added absolute path with relative one in AES_DECRYPT example.

/home/work/Work/Raptor/tests/Testcases/aes_decrypt_fpga -> $OSRCDIR/AES_DECRYPT.srcs/sources_1