### PR TITLE
[GEMINIEDA-340] Remove statuses from examples tasks

### DIFF
--- a/examples/AES_DECRYPT/AES_DECRYPT.ospr
+++ b/examples/AES_DECRYPT/AES_DECRYPT.ospr
@@ -61,8 +61,8 @@
         </Run>
     </Runs>
     <Tasks Version="0.0.0">
-        <Task ID="0" Status="2"/>
-        <Task ID="1" Status="3"/>
+        <Task ID="0" Status="0"/>
+        <Task ID="1" Status="0"/>
         <Task ID="4" Status="0"/>
         <Task ID="5" Status="0"/>
         <Task ID="6" Status="0"/>
@@ -75,7 +75,7 @@
         <Task ID="19" Status="0"/>
         <Task ID="20" Status="0"/>
         <Task ID="21" Status="0"/>
-        <Task ID="23" Status="2"/>
+        <Task ID="23" Status="0"/>
     </Tasks>
     <Compiler Version="0.0.0" CompilerState="10"/>
 </Project>

--- a/examples/and2_gemini/and2_gemini.ospr
+++ b/examples/and2_gemini/and2_gemini.ospr
@@ -38,10 +38,10 @@
     </Runs>
     <Tasks Version="0.0.0">
         <Task ID="0" Status="0"/>
-        <Task ID="1" Status="2"/>
+        <Task ID="1" Status="0"/>
         <Task ID="4" Status="0"/>
         <Task ID="5" Status="0"/>
-        <Task ID="6" Status="2"/>
+        <Task ID="6" Status="0"/>
         <Task ID="8" Status="0"/>
         <Task ID="10" Status="0"/>
         <Task ID="13" Status="0"/>
@@ -51,7 +51,7 @@
         <Task ID="19" Status="0"/>
         <Task ID="20" Status="0"/>
         <Task ID="21" Status="0"/>
-        <Task ID="23" Status="2"/>
+        <Task ID="23" Status="0"/>
     </Tasks>
     <Compiler Version="0.0.0" CompilerState="4"/>
 </Project>

--- a/examples/incr_comp/incr_comp.ospr
+++ b/examples/incr_comp/incr_comp.ospr
@@ -36,7 +36,7 @@
     </Runs>
     <Tasks Version="0.0.0">
         <Task ID="0" Status="0"/>
-        <Task ID="1" Status="2"/>
+        <Task ID="1" Status="0"/>
         <Task ID="4" Status="0"/>
         <Task ID="5" Status="0"/>
         <Task ID="6" Status="0"/>

--- a/examples/sasc_testcase/sasc_testcase.ospr
+++ b/examples/sasc_testcase/sasc_testcase.ospr
@@ -40,7 +40,7 @@
         </Run>
     </Runs>
     <Tasks Version="0.0.0">
-        <Task ID="0" Status="2"/>
+        <Task ID="0" Status="0"/>
         <Task ID="1" Status="0"/>
         <Task ID="4" Status="0"/>
         <Task ID="5" Status="0"/>
@@ -54,7 +54,7 @@
         <Task ID="19" Status="0"/>
         <Task ID="20" Status="0"/>
         <Task ID="21" Status="0"/>
-        <Task ID="23" Status="3"/>
+        <Task ID="23" Status="0"/>
     </Tasks>
     <Compiler Version="0.0.0" CompilerState="10"/>
 </Project>


### PR DESCRIPTION
These changes aim to fix the issue in Raptor examples, when example projects are opened with pre-filled statuses already.

Task statuses are simply removed from project files of all the examples.