### PR TITLE
[RG-139] Add mode column for pin planner

### DIFF
--- a/etc/package_pin_info.json
+++ b/etc/package_pin_info.json
@@ -20,75 +20,81 @@
       "visible" : true
     },
     {
+      "name" : "Mode",
+      "description" : "Mode of the gearbox",
+      "colmumnid" : 3,
+      "visible" : true
+    },
+    {
       "name" : "Ref clock",
       "description" : "Clock name referenced by pin",
-      "colmumnid" : 3,
+      "colmumnid" : 4,
       "visible" : true
     },
     {
       "name" : "Bank",
       "description" : "IO bank name",
-      "colmumnid" : 4,
+      "colmumnid" : 5,
       "visible" : true
     },
     {
       "name" : "ALT",
       "description" : "Alternative function of pin",
-      "colmumnid" : 5,
+      "colmumnid" : 6,
       "visible" : true
     },
     {
       "name" : "Debug mode",
       "description" : "Available debug mode of pin",
-      "colmumnid" : 6,
+      "colmumnid" : 7,
       "visible" : true
     },
     {
       "name" : "Scan mode",
       "description" : "Available scan mode of pin",
-      "colmumnid" : 7,
+      "colmumnid" : 8,
       "visible" : true
     },
     {
       "name" : "Mbist mode",
       "description" : "Memory test mode of pin",
-      "colmumnid" : 8,
+      "colmumnid" : 9,
       "visible" : true
     },
     {
       "name" : "Type",
       "description" : "Pin type",
-      "colmumnid" : 9,
+      "colmumnid" : 10,
       "visible" : true
     },
     {
       "name" : "Dir",
       "description" : "Input/output direction of pin",
-      "colmumnid" : 10,
+      "colmumnid" : 11,
       "visible" : true
     },
     {
       "name" : "Voltage",
       "description" : "Pin operating voltage",
-      "colmumnid" : 11,
+      "colmumnid" : 12,
       "visible" : true
     },
     {
       "name" : "Power Pad",
       "description" : "Power pad of pin",
-      "colmumnid" : 12,
+      "colmumnid" : 13,
       "visible" : true
     },
     {
       "name" : "Description",
       "description" : "Pin description for further reference",
-      "colmumnid" : 13,
+      "colmumnid" : 14,
       "visible" : true
     },
     {
       "name" : "Voltage2",
       "description" : "Secondary operating voltage if available",
-      "colmumnid" : 14,
+      "colmumnid" : 15,
       "visible" : true
     }
   ]


### PR DESCRIPTION
Support mode column for pin planner
Pending https://github.com/RapidSilicon/Raptor/pull/384

┆Issue is synchronized with this [Jira Bug](https://rapidsilicon.atlassian.net/browse/EDA-579) by [Unito](https://www.unito.io)
