### PR TITLE
Add run_project test to raptor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ test_install:
 
 test/gui: run-cmake-debug
 	$(XVFB) ./dbuild/bin/raptor --compiler dummy --replay tests/TestGui/gui_foedag.tcl
+	$(XVFB) ./dbuild/bin/raptor --script tests/TestGui/gui_run_incr_comp_project.tcl
 
 test/rs: run-cmake-release
 	./build/bin/raptor --batch --script tests/Testcases/aes_decrypt_fpga/aes_decrypt.tcl

--- a/tests/TestGui/gui_run_incr_comp_project.tcl
+++ b/tests/TestGui/gui_run_incr_comp_project.tcl
@@ -1,0 +1,34 @@
+#Copyright 2021 The Foedag team
+
+#GPL License
+
+#Copyright (c) 2021 The Open-Source FPGA Foundation
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+puts "RUNNING PROJECT"
+run_project examples/incr_comp/incr_comp.ospr
+set fp [open "raptor.log" r]
+set file_data [read $fp]
+close $fp
+# Report an error if project run wasn't successful
+set found [regexp "Project run successful" $file_data]
+if { !$found } {
+     puts "TEST FAILED: incr_comp.ospr run failed."
+     exit 1
+}
+
+puts "TEST SUCCEEDED"
+
+exit 0


### PR DESCRIPTION
Added GUI test on run_project tcl command.
So far only one project is run in order not to explode CI execution time.