### PR TITLE
source setup script to enable simulator

### DIFF
--- a/src/.raptorenv_lin64.sh
+++ b/src/.raptorenv_lin64.sh
@@ -31,3 +31,6 @@ if [ -n "${PYTHONPATH}" ]; then
 else
 	export PYTHONPATH=$RAPTOR_PATH/share/litex_reference_designs/:$RAPTOR_PATH/share/raptor/IP_Catalog/
 fi
+[[ -f "$RAPTOR_PATH/bin/HDL_simulator/setup_sim" ]] && source $RAPTOR_PATH/bin/HDL_simulator/setup_sim
+
+


### PR DESCRIPTION
 Now when end user will source the raptor setup script, the sim setup script will be sourced as well to run verilator as standalone, 
[Jira Ticket](https://rapidsilicon.atlassian.net/browse/EDA-683) 