### PR TITLE
[RG-222] adding etc/copyright.txt for log headers

### DIFF
--- a/etc/copyright.txt
+++ b/etc/copyright.txt
@@ -1,0 +1,1 @@
+Copyright 2022 RapidSilicon


### PR DESCRIPTION
This is related to https://github.com/os-fpga/FOEDAG/pull/856, but doesn't need it to be merged first as it's just adding a file.

This file will be read and added to the header of logs mentioned in the PR above.

The current copyright text is just a basic placeholder so we have something, but it should be updated once we know the official copyright info we want to include.