### PR TITLE
GTKWave: install/uninstall update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,11 @@ add_custom_command(TARGET raptor POST_BUILD
           ${CMAKE_CURRENT_SOURCE_DIR}/FOEDAG_rs/FOEDAG/third_party/tcl8.6.12/library/init.tcl
           ${CMAKE_CURRENT_BINARY_DIR}/lib/tcl8.6/init.tcl)
 
+add_custom_command(TARGET raptor POST_BUILD
+  COMMENT "Extracting gtkwave"
+  COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_SOURCE_DIR}/FOEDAG_rs/FOEDAG/third_party/gtkwave_cmake/gtkwaveTCL.tar.gz
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 # Explicit lib build order
 add_dependencies(raptor raptor_gui)
 if (NOT APPLE)
@@ -620,6 +625,8 @@ install(
       WORLD_READ WORLD_EXECUTE
       )
 
+install(
+  DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gtkwave DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 #install(
 #  EXPORT Raptor

--- a/Makefile
+++ b/Makefile
@@ -187,4 +187,5 @@ uninstall:
 	$(RM) -r $(PREFIX)/lib/raptor
 	$(RM) -r $(PREFIX)/include/raptor
 	$(RM) -r $(PREFIX)/share/raptor
+	$(RM) -r $(PREFIX)/bin/gtkwave
 


### PR DESCRIPTION
### This change is related to https://github.com/os-fpga/FOEDAG/pull/871 and should wait for it to be merged first

This adds install/extract/uninstall targets for FOEDAG's gtkwave