### PR TITLE
[RG-230] Remove global_placement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Tcl commands (Available in GUI or Batch console or Batch script):
                               : Uses alternate bitstream generation configuration files
    set_device_size XxY        : Device fabric size selection
    packing ?clean?            : Packing
-   global_placement ?clean?   : Analytical placer
    place ?clean?              : Detailed placer
    route ?clean?              : Router
    sta ?clean? ?opensta?      : Statistical Timing Analysis with Tatum (Default) or OpenSTA


### PR DESCRIPTION
This is related to https://github.com/os-fpga/FOEDAG/pull/876

Global Placement has been disabled for the Jan'23 release.