### PR TITLE
[RG-240] Add sta settings for Raptor

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -245,6 +245,27 @@
                 "isSetting": true
             }
         },
+        "Timing Analysis": {
+            "engine_radiobtn": {
+                "label": "Timing Engine:",
+                "widgetType": "radiobuttons",
+                "options": [
+                    "Tatum",
+                    "OpenSTA"
+                ],
+                "optionsLookup": [
+                    "tatum",
+                    "opensta"
+                ],
+                "layout": "horizontal",
+                "arg": "_StaOpt_"
+            },
+            "_META_": {
+                "hidden": false,
+                "isSetting": true,
+                "tclArgKey": "Tasks_TimingAnalysis"
+            }
+        },
         "Simulate RTL": {
             "_META_": {
                 "hidden": true,


### PR DESCRIPTION
### This won't take affect until https://github.com/os-fpga/FOEDAG/pull/890 and https://github.com/RapidSilicon/FOEDAG_rs/pull/264 are merged.

This updates the settings json to display the timing engine options.