### PR TITLE
[RG-321] Remove None values from the synth settings

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -159,14 +159,12 @@
                 "options": [
                     "High",
                     "Medium",
-                    "Low",
-                    "None"
+                    "Low"
                 ],
                 "optionsLookup": [
                     "high",
                     "medium",
-                    "low",
-                    "none"
+                    "low"
                 ],
                 "arg": "effort",
                 "default":"high"
@@ -176,13 +174,11 @@
                 "widgetType": "dropdown",
                 "options": [
                     "Binary",
-                    "One Hot",
-                    "None"
+                    "One Hot"
                 ],
                 "optionsLookup": [
                     "binary",
-                    "onehot",
-                    "none"
+                    "onehot"
                 ],
                 "arg": "fsm_encoding",
                 "default":"onehot"
@@ -201,7 +197,6 @@
                     "none"
                 ],
                 "arg": "carry",
-                "addUnset": true,
                 "default":"auto"
             },
             "netlist_lang_dropdown": {


### PR DESCRIPTION
Close [RG-321]

[RG-321]: https://rapidsilicon.atlassian.net/browse/RG-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![image](https://user-images.githubusercontent.com/95262932/218704186-eff31e61-12da-4df6-b984-7872fa9db669.png)
![image](https://user-images.githubusercontent.com/95262932/218704273-69fd841f-a4b4-47e6-b514-ed8f877bf5af.png)
![image](https://user-images.githubusercontent.com/95262932/218704322-b5f54434-28b8-42b3-8875-a9075dd65683.png)
