### PR TITLE
updated scaling and added DSP values

### DIFF
--- a/etc/devices/gemini_100K/gemini_vpr.xml
+++ b/etc/devices/gemini_100K/gemini_vpr.xml
@@ -940,10 +940,10 @@
     <connection_block input_switch_name="ipin_cblock"/>
   </device>
   <switchlist>
-    <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="0" Tdel="1.43784e-10" mux_trans_size="1.222260" buf_size="auto"/>
-    <switch type="mux" name="L1_mux" R="0." Cin="0" Cout="0." Tdel="5.11345e-11" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <switch type="mux" name="L2_mux" R="0." Cin="0" Cout="0." Tdel="5.11345e-11" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <switch type="mux" name="L4_mux" R="0." Cin="0" Cout="0." Tdel="1.23425e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="0" Tdel="1e-10" mux_trans_size="1.222260" buf_size="auto"/>
+    <switch type="mux" name="L1_mux" R="0." Cin="0" Cout="0." Tdel="9.14e-11" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L2_mux" R="0." Cin="0" Cout="0." Tdel="9.14e-11" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <switch type="mux" name="L4_mux" R="0." Cin="0" Cout="0." Tdel="1.784e-10" mux_trans_size="2.630740" buf_size="27.645901"/>
   </switchlist>
   <segmentlist>
     <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
@@ -1416,7 +1416,7 @@
                 <delay_constant max="3.6966e-11" min="1.8483e-11" in_port="adder_carry.cin" out_port="adder_carry.sumout"/>
                 <delay_constant max="2.8365e-11" min="1.41825e-11" in_port="adder_carry.p" out_port="adder_carry.cout"/>
                 <delay_constant max="3.843e-11" min="1.9215e-11" in_port="adder_carry.g" out_port="adder_carry.cout"/>
-                <delay_constant max="2.75213e-11" min="2.52905e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
+                <delay_constant max="2.756e-11" min="2.528e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
               </pb_type>
               <interconnect>
                 <direct name="direct1" input="frac_logic.in[5:0]" output="frac_lut6.in[5:0]"/>
@@ -1425,23 +1425,10 @@
                 <direct name="direct4" input="frac_lut6.lut4_out[1]" output="adder_carry[0].g"/>
                 <direct name="direct6" input="frac_lut6.lut4_out[2]" output="adder_carry[1].p"/>
                 <direct name="direct7" input="frac_lut6.lut4_out[3]" output="adder_carry[1].g"/>
-                <direct name="direct9" input="adder_carry[0].cout" output="adder_carry[1].cin">
-                  <delay_constant max="4.7193e-11" min="3.7138e-11" in_port="adder_carry[0].cout" out_port="adder_carry[1].cin"/>
-                </direct>
+                <direct name="direct9" input="adder_carry[0].cout" output="adder_carry[1].cin"/>
                 <direct name="direct10" input="adder_carry[1].cout" output="frac_logic.cout"/>
-                <mux name="mux0" input="adder_carry[0].sumout adder_carry[0].cout frac_lut6.lut5_out[0] frac_logic.reg_in" output="frac_logic.out[0]">
-                  <delay_constant max="1.3725e-10" min="1.281e-10" in_port="adder_carry[0].sumout" out_port="frac_logic.out[0]"/>
-                  <delay_constant max="1.464e-10" min="1.3725e-10" in_port="adder_carry[0].cout" out_port="frac_logic.out[0]"/>
-                  <delay_constant max="1.0065e-10" min="9.15e-11" in_port="frac_lut6.lut5_out[0]" out_port="frac_logic.out[0]"/>
-                  <delay_constant max="1.098e-10" min="9.15e-11" in_port="frac_logic.reg_in" out_port="frac_logic.out[0]"/>
-                </mux>
-                <mux name="mux1" input="adder_carry[1].sumout adder_carry[1].cout frac_lut6.lut5_out[1] frac_lut6.lut6_out frac_logic.regchain[0]" output="frac_logic.out[1]">
-                  <delay_constant max="1.3725e-10" min="1.281e-10" in_port="adder_carry[1].sumout" out_port="frac_logic.out[1]"/>
-                  <delay_constant max="1.464e-10" min="1.3725e-10" in_port="adder_carry[1].cout" out_port="frac_logic.out[1]"/>
-                  <delay_constant max="1.0065e-10" min="9.15e-11" in_port="frac_lut6.lut5_out[1]" out_port="frac_logic.out[1]"/>
-                  <delay_constant max="1.0065e-10" min="9.15e-11" in_port="frac_lut6.lut6_out" out_port="frac_logic.out[1]"/>
-                  <delay_constant max="1.098e-10" min="9.15e-11" in_port="frac_logic.regchain[0]" out_port="frac_logic.out[1]"/>
-                </mux>
+                <mux name="mux0" input="adder_carry[0].sumout adder_carry[0].cout frac_lut6.lut5_out[0] frac_logic.reg_in" output="frac_logic.out[0]"/>
+                <mux name="mux1" input="adder_carry[1].sumout adder_carry[1].cout frac_lut6.lut5_out[1] frac_lut6.lut6_out frac_logic.regchain[0]" output="frac_logic.out[1]"/>
               </interconnect>
             </pb_type>
             <pb_type name="ff_phy" blif_model=".subckt scff" num_pb="2">
@@ -1483,14 +1470,8 @@
               <direct name="direct_fabric_scout" input="ff_phy[1].SO" output="fabric.sc_out"/>
               <direct name="direct_frac_out1" input="frac_logic.out[0]" output="ff_phy[0].D"/>
               <direct name="direct_frac_out2" input="frac_logic.out[1]" output="ff_phy[1].D"/>
-              <mux name="mux2" input="frac_logic.out[0] ff_phy[0].Q" output="fabric.out[0]">
-                <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="frac_logic.out[0]" out_port="fabric.out[0]"/>
-                <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="ff_phy[0].Q" out_port="fabric.out[0]"/>
-              </mux>
-              <mux name="mux3" input="frac_logic.out[1] ff_phy[1].Q" output="fabric.out[1]">
-                <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="frac_logic.out[1]" out_port="fabric.out[1]"/>
-                <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="ff_phy[1].Q" out_port="fabric.out[1]"/>
-              </mux>
+              <mux name="mux2" input="frac_logic.out[0] ff_phy[0].Q" output="fabric.out[0]"/>
+              <mux name="mux3" input="frac_logic.out[1] ff_phy[1].Q" output="fabric.out[1]"/>
             </interconnect>
           </pb_type>
           <interconnect>
@@ -1799,10 +1780,7 @@
               <direct name="direct6" input="ble6.enable" output="ff.E"/>
               <direct name="direct7" input="ble6.sync_set" output="ff.SYNC_S"/>
               <direct name="direct8" input="ble6.sync_reset" output="ff.SYNC_R"/>
-              <mux name="mux4" input="lut6.out ff.Q" output="ble6.out">
-                <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="ff.Q" out_port="ble6.out"/>
-                <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="lut6.out" out_port="ble6.out"/>
-              </mux>
+              <mux name="mux4" input="lut6.out ff.Q" output="ble6.out"/>
             </interconnect>
           </pb_type>
           <interconnect>
@@ -2129,10 +2107,7 @@
                     <direct name="direct6" input="flut5.enable" output="ff.E"/>
                     <direct name="direct7" input="flut5.sync_set" output="ff.SYNC_S"/>
                     <direct name="direct8" input="flut5.sync_reset" output="ff.SYNC_R"/>
-                    <mux name="mux5" input="lut5.out ff.Q" output="flut5.out">
-                      <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="ff.Q" out_port="flut5.out"/>
-                      <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="lut5.out" out_port="flut5.out"/>
-                    </mux>
+                    <mux name="mux5" input="lut5.out ff.Q" output="flut5.out"/>
                   </interconnect>
                 </pb_type>
                 <interconnect>
@@ -2185,7 +2160,7 @@
                       <delay_constant max="3.6966e-11" min="1.8483e-11" in_port="adder_carry.cin" out_port="adder_carry.sumout"/>
                       <delay_constant max="2.8365e-11" min="1.41825e-11" in_port="adder_carry.p" out_port="adder_carry.cout"/>
                       <delay_constant max="3.843e-11" min="1.9215e-11" in_port="adder_carry.g" out_port="adder_carry.cout"/>
-                      <delay_constant max="2.75213e-11" min="2.52913e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
+                      <delay_constant max="2.756e-11" min="2.528e-11" in_port="adder_carry.cin" out_port="adder_carry.cout"/>
                     </pb_type>
                     <interconnect>
                       <direct name="direct2" input="adder.in[3:0]" output="lut4[0:0].in[3:0]"/>
@@ -2199,10 +2174,7 @@
                         <pack_pattern name="carrychain" in_port="adder_carry.cout" out_port="adder.cout"/>
                       </direct>
                       <!-- CHECK -->
-                      <mux name="mux6" input="adder_carry.sumout adder_carry.cout" output="adder.out">
-                        <delay_constant max="1.464e-10" min="1.3725e-10" in_port="adder_carry.sumout" out_port="adder.out"/>
-                        <delay_constant max="1.464e-10" min="1.3725e-10" in_port="adder_carry.cout" out_port="adder.out"/>
-                      </mux>
+                      <mux name="mux6" input="adder_carry.sumout adder_carry.cout" output="adder.out"/>
                     </interconnect>
                   </pb_type>
                   <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
@@ -2225,10 +2197,7 @@
                     <direct name="carry_out" input="adder.cout" output="soft_adder.cout">
                       <pack_pattern name="carrychain" in_port="adder.cout" out_port="soft_adder.cout"/>
                     </direct>
-                    <mux name="mux7" input="adder.out ff.Q" output="soft_adder.out">
-                      <delay_constant max="1.464e-10" min="1.3725e-10" in_port="adder.out" out_port="soft_adder.out"/>
-                      <delay_constant max="1.464e-10" min="1.3725e-10" in_port="ff.Q" out_port="soft_adder.out"/>
-                    </mux>
+                    <mux name="mux7" input="adder.out ff.Q" output="soft_adder.out"/>
                   </interconnect>
                 </pb_type>
                 <interconnect>
@@ -2252,7 +2221,6 @@
               </direct>
               <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
                 <pack_pattern name="carrychain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cin"/>
-                <delay_constant max="5.1577e-11" min="4.0588e-11" in_port="ble5[0:0].cout" out_port="ble5[1:1].cin"/>
               </direct>
               <complete name="set" input="lut5inter.set" output="ble5[1:0].set"/>
               <complete name="reset" input="lut5inter.reset" output="ble5[1:0].reset"/>
@@ -2314,7 +2282,6 @@
               </direct>
               <direct name="direct2" input="ff[0].Q" output="ff[1].D">
                 <pack_pattern name="shiftchain" in_port="ff[0].Q" out_port="ff[1].D"/>
-                <delay_constant max="5.1445e-11" min="3.68223e-11" in_port="ff[0].Q" out_port="ff[1].D"/>
               </direct>
               <direct name="direct3" input="ff[0].Q" output="shift_reg.out[0]"/>
               <direct name="direct4" input="ff[1].Q" output="shift_reg.out[1]"/>
@@ -2340,25 +2307,25 @@
       </pb_type>
       <interconnect>
         <complete name="crossbar0" input="clb.I0 clb.I3 fle[1:0].out fle[3:2].out " output="fle[7:0].in[0]">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.I0 clb.I3" out_port="fle[7:0].in[0]"/>
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="fle[1:0].out fle[3:2].out fle[7:7].out" out_port="fle[7:0].in[0]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.I0 clb.I3" out_port="fle[7:0].in[0]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="fle[1:0].out fle[3:2].out fle[7:7].out" out_port="fle[7:0].in[0]"/>
         </complete>
         <complete name="crossbar1" input="clb.I1 clb.I2 fle[3:2].out fle[5:4].out fle[7:7].out" output="fle[7:0].in[1]">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.I1 clb.I2" out_port="fle[7:0].in[1]"/>
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="fle[3:2].out fle[5:4].out fle[7:7].out" out_port="fle[7:0].in[1]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.I1 clb.I2" out_port="fle[7:0].in[1]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="fle[3:2].out fle[5:4].out fle[7:7].out" out_port="fle[7:0].in[1]"/>
         </complete>
         <complete name="crossbar2" input="clb.I0 clb.I2 fle[5:4].out fle[7:6].out" output="fle[7:0].in[2]">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.I0 clb.I2" out_port="fle[7:0].in[2]"/>
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="fle[5:4].out fle[7:6].out " out_port="fle[7:0].in[2]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.I0 clb.I2" out_port="fle[7:0].in[2]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="fle[5:4].out fle[7:6].out " out_port="fle[7:0].in[2]"/>
         </complete>
         <complete name="crossbar3" input="clb.I1 clb.I3" output="fle[7:0].in[3]">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.I1 clb.I3" out_port="fle[7:0].in[3]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.I1 clb.I3" out_port="fle[7:0].in[3]"/>
         </complete>
         <complete name="crossbar4" input="clb.I0 clb.I3" output="fle[7:0].in[4]">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.I0 clb.I3" out_port="fle[7:0].in[4]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.I0 clb.I3" out_port="fle[7:0].in[4]"/>
         </complete>
         <complete name="crossbar5" input="clb.I1 clb.I2" output="fle[7:0].in[5]">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.I1 clb.I2" out_port="fle[7:0].in[5]"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.I1 clb.I2" out_port="fle[7:0].in[5]"/>
         </complete>
         <complete name="clks" input="clb.clk" output="fle[7:0].clk">
           <delay_constant max="9.15e-13" min="9.15e-13" in_port="clb.clk[0]" out_port="fle[7:0].clk"/>
@@ -2379,35 +2346,29 @@
           <delay_constant max="1.8386e-11" min="1.8386e-11" in_port="clb.sync_reset" out_port="fle[7:0].sync_reset"/>
         </complete>
         <complete name="enable" input="clb.enable" output="fle[7:0].enable">
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.enable" out_port="fle[7:0].enable"/>
+          <delay_constant max="6e-11" min="2.0313e-11" in_port="clb.enable" out_port="fle[7:0].enable"/>
         </complete>
         <direct name="clbouts1" input="fle[7:0].out[0:0]" output="clb.O[7:0]"/>
         <direct name="clbouts2" input="fle[7:0].out[1:1]" output="clb.O[17:10]"/>
         <!-- Shift register links -->
         <direct name="shift_reg_in" input="clb.reg_in" output="fle[0:0].reg_in">
           <pack_pattern name="shiftchain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
         </direct>
         <direct name="shift_reg_out" input="fle[7:7].reg_out" output="clb.reg_out">
           <pack_pattern name="shiftchain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/>
-          <delay_constant max="5.1445e-11" min="3.68223e-11" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/>
         </direct>
         <direct name="shift_reg_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
           <pack_pattern name="shiftchain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/>
-          <delay_constant max="1.55825e-10" min="2.0313e-11" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/>
         </direct>
         <!-- Carry chain links -->
         <complete name="carry_in" input="clb.cin clb.cin_trick" output="fle[0:0].cin">
           <pack_pattern name="carrychain" in_port="clb.cin" out_port="fle[0:0].cin"/>
-          <delay_constant max="1.12052e-10" min="9.20517e-11" in_port="clb.cin" out_port="fle[0:0].cin"/>
         </complete>
         <direct name="carry_out" input="fle[7:7].cout" output="clb.cout">
           <pack_pattern name="carrychain" in_port="fle[7:7].cout" out_port="clb.cout"/>
-          <delay_constant max="5.1445e-11" min="3.68223e-11" in_port="fle[7:7].cout" out_port="clb.cout"/>
         </direct>
         <direct name="carry_link" input="fle[6:0].cout" output="fle[7:1].cin">
           <pack_pattern name="carrychain" in_port="fle[7:0].cout" out_port="fle[7:1].cin"/>
-          <delay_constant max="4.7193e-11" min="3.7138e-11" in_port="fle[6:0].cout" out_port="fle[7:1].cin"/>
         </direct>
         <!-- Scan chain links -->
         <direct name="scff_in" input="clb.sc_in" output="fle[0:0].sc_in"/>
@@ -2464,9 +2425,9 @@
           <output name="dly_b_o" num_pins="18"/>
           <output name="sc_out" num_pins="3"/>
           <!--
-	  <delay_constant max="3.2025e-09" in_port="dsp_phy.a_i" out_port="dsp_phy.z_o"/>
-	  <delay_constant max="3.2025e-09" in_port="dsp_phy.acc_fir_i" out_port="dsp_phy.z_o"/>
-	  <delay_constant max="3.2025e-09" in_port="dsp_phy.b_i" out_port="dsp_phy.z_o"/>
+	  <delay_constant max="3.01639e-09" in_port="dsp_phy.a_i" out_port="dsp_phy.z_o"/>
+	  <delay_constant max="3.01639e-09" in_port="dsp_phy.acc_fir_i" out_port="dsp_phy.z_o"/>
+	  <delay_constant max="2.91464e-09" in_port="dsp_phy.b_i" out_port="dsp_phy.z_o"/>
 -->
           <T_setup value="1.83e-10" port="dsp_phy.a_i" clock="clk"/>
           <T_setup value="1.83e-10" port="dsp_phy.b_i" clock="clk"/>
@@ -2531,20 +2492,20 @@
           <clock name="clk" num_pins="1"/>
           <output name="z" num_pins="38"/>
           <output name="dly_b" num_pins="18"/>
-          <delay_constant max="3.2025e-09" in_port="RS_DSP2.a" out_port="RS_DSP2.z"/>
-          <delay_constant max="3.2025e-09" in_port="RS_DSP2.acc_fir" out_port="RS_DSP2.z"/>
-          <delay_constant max="3.2025e-09" in_port="RS_DSP2.b" out_port="RS_DSP2.z"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.load_acc" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.reset" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.feedback" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.unsigned_a" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.unsigned_b" clock="clk"/>
+          <delay_constant max="3.01639e-09" in_port="RS_DSP2.a" out_port="RS_DSP2.z"/>
+          <delay_constant max="3.01639e-09" in_port="RS_DSP2.acc_fir" out_port="RS_DSP2.z"/>
+          <delay_constant max="2.91464e-09" in_port="RS_DSP2.b" out_port="RS_DSP2.z"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2.load_acc" clock="clk"/>
+          <T_setup value="1.67558e-10" port="RS_DSP2.reset" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2.feedback" clock="clk"/>
+          <T_setup value="3.20506e-11" port="RS_DSP2.unsigned_a" clock="clk"/>
+          <T_setup value="3.36144e-11" port="RS_DSP2.unsigned_b" clock="clk"/>
           <T_setup value="4.575e-10" port="RS_DSP2.f_mode" clock="clk"/>
           <T_setup value="4.575e-10" port="RS_DSP2.output_select" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.saturate_enable" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.shift_right" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.round" clock="clk"/>
-          <T_setup value="4.575e-10" port="RS_DSP2.subtract" clock="clk"/>
+          <T_setup value="4.3565e-11" port="RS_DSP2.saturate_enable" clock="clk"/>
+          <T_setup value="7.81392e-11" port="RS_DSP2.shift_right" clock="clk"/>
+          <T_setup value="4.52788e-11" port="RS_DSP2.round" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2.subtract" clock="clk"/>
           <T_setup value="4.575e-10" port="RS_DSP2.register_inputs" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2580,8 +2541,8 @@
           <input name="register_inputs" num_pins="1"/>
           <input name="reset" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <delay_constant max="1.83e-10" min="1.83e-10" in_port="RS_DSP2_MULT.a" out_port="RS_DSP2_MULT.z"/>
-          <delay_constant max="1.83e-10" min="1.83e-10" in_port="RS_DSP2_MULT.b" out_port="RS_DSP2_MULT.z"/>
+          <delay_constant max="3.01639e-09" min="4.76801e-10" in_port="RS_DSP2_MULT.a" out_port="RS_DSP2_MULT.z"/>
+          <delay_constant max="2.91464e-09" min="6.65088e-10" in_port="RS_DSP2_MULT.b" out_port="RS_DSP2_MULT.z"/>
         </pb_type>
         <interconnect>
           <direct name="direct1" input="dsp.a_i" output="RS_DSP2_MULT.a"/>
@@ -2609,9 +2570,9 @@
           <input name="reset" num_pins="1"/>
           <clock name="clk" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN.feedback" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULT_REGIN.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULT_REGIN.b" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULT_REGIN.feedback" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULT_REGIN.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2641,9 +2602,9 @@
           <input name="reset" num_pins="1"/>
           <clock name="clk" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGOUT.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGOUT.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGOUT.feedback" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULT_REGOUT.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULT_REGOUT.b" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULT_REGOUT.feedback" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULT_REGOUT.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2673,15 +2634,15 @@
           <input name="reset" num_pins="1"/>
           <clock name="clk" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.feedback" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULT_REGIN_REGOUT.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULT_REGIN_REGOUT.b" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULT_REGIN_REGOUT.feedback" clock="clk"/>
           <T_setup value="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.a" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULT_REGIN_REGOUT.b" clock="clk"/>
-          <delay_constant max="1.83e-10" in_port="RS_DSP2_MULT_REGIN_REGOUT.a" out_port="RS_DSP2_MULT_REGIN_REGOUT.z"/>
-          <delay_constant max="1.83e-10" in_port="RS_DSP2_MULT_REGIN_REGOUT.b" out_port="RS_DSP2_MULT_REGIN_REGOUT.z"/>
+          <delay_constant max="3.01639e-09" in_port="RS_DSP2_MULT_REGIN_REGOUT.a" out_port="RS_DSP2_MULT_REGIN_REGOUT.z"/>
+          <delay_constant max="2.91464e-09" in_port="RS_DSP2_MULT_REGIN_REGOUT.b" out_port="RS_DSP2_MULT_REGIN_REGOUT.z"/>
         </pb_type>
         <interconnect>
           <direct name="direct1" input="dsp.a_i" output="RS_DSP2_MULT_REGIN_REGOUT.a"/>
@@ -2715,8 +2676,8 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <delay_constant max="1.83e-10" min="1.83e-10" in_port="RS_DSP2_MULTADD.a" out_port="RS_DSP2_MULTADD.z"/>
-          <delay_constant max="1.83e-10" min="1.83e-10" in_port="RS_DSP2_MULTADD.b" out_port="RS_DSP2_MULTADD.z"/>
+          <delay_constant max="3.01639e-09" min="4.76801e-10" in_port="RS_DSP2_MULTADD.a" out_port="RS_DSP2_MULTADD.z"/>
+          <delay_constant max="2.91464e-09" min="6.65088e-10" in_port="RS_DSP2_MULTADD.b" out_port="RS_DSP2_MULTADD.z"/>
           <delay_constant max="1.83e-10" min="1.83e-10" in_port="RS_DSP2_MULTADD.subtract" out_port="RS_DSP2_MULTADD.z"/>
           <delay_constant max="1.83e-10" min="1.83e-10" in_port="RS_DSP2_MULTADD.acc_fir" out_port="RS_DSP2_MULTADD.z"/>
         </pb_type>
@@ -2758,12 +2719,12 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN.load_acc" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN.acc_fir" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTADD_REGIN.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTADD_REGIN.b" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTADD_REGIN.subtract" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTADD_REGIN.feedback" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTADD_REGIN.load_acc" clock="clk"/>
+          <T_setup value="3.90431e-11" port="RS_DSP2_MULTADD_REGIN.acc_fir" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTADD_REGIN.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2805,12 +2766,12 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.load_acc" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.acc_fir" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTADD_REGOUT.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTADD_REGOUT.b" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTADD_REGOUT.subtract" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTADD_REGOUT.feedback" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTADD_REGOUT.load_acc" clock="clk"/>
+          <T_setup value="3.90431e-11" port="RS_DSP2_MULTADD_REGOUT.acc_fir" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTADD_REGOUT.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2852,12 +2813,12 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.load_acc" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.acc_fir" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTADD_REGIN_REGOUT.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTADD_REGIN_REGOUT.b" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTADD_REGIN_REGOUT.subtract" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTADD_REGIN_REGOUT.feedback" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTADD_REGIN_REGOUT.load_acc" clock="clk"/>
+          <T_setup value="3.90431e-11" port="RS_DSP2_MULTADD_REGIN_REGOUT.acc_fir" clock="clk"/>
           <T_setup value="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.z" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTADD_REGIN_REGOUT.a" clock="clk"/>
@@ -2907,11 +2868,11 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC.load_acc" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTACC.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTACC.b" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTACC.feedback" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTACC.subtract" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTACC.load_acc" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTACC.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2951,11 +2912,11 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN.load_acc" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTACC_REGIN.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTACC_REGIN.b" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTACC_REGIN.subtract" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTACC_REGIN.feedback" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTACC_REGIN.load_acc" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTACC_REGIN.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -2995,11 +2956,11 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGOUT.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGOUT.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGOUT.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGOUT.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGOUT.load_acc" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTACC_REGOUT.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTACC_REGOUT.b" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTACC_REGOUT.feedback" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTACC_REGOUT.subtract" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTACC_REGOUT.load_acc" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTACC_REGOUT.z" clock="clk"/>
         </pb_type>
         <interconnect>
@@ -3039,11 +3000,11 @@
           <input name="shift_right" num_pins="6"/>
           <input name="round" num_pins="1"/>
           <output name="z" num_pins="38"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN_REGOUT.a" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN_REGOUT.b" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN_REGOUT.subtract" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN_REGOUT.feedback" clock="clk"/>
-          <T_setup value="1.83e-10" port="RS_DSP2_MULTACC_REGIN_REGOUT.load_acc" clock="clk"/>
+          <T_setup value="8.80651e-11" port="RS_DSP2_MULTACC_REGIN_REGOUT.a" clock="clk"/>
+          <T_setup value="5.4555e-11" port="RS_DSP2_MULTACC_REGIN_REGOUT.b" clock="clk"/>
+          <T_setup value="4.19921e-11" port="RS_DSP2_MULTACC_REGIN_REGOUT.subtract" clock="clk"/>
+          <T_setup value="4.26719e-11" port="RS_DSP2_MULTACC_REGIN_REGOUT.feedback" clock="clk"/>
+          <T_setup value="4.47206e-11" port="RS_DSP2_MULTACC_REGIN_REGOUT.load_acc" clock="clk"/>
           <T_clock_to_Q max="1.83e-10" port="RS_DSP2_MULTACC_REGIN_REGOUT.z" clock="clk"/>
         </pb_type>
         <interconnect>


### PR DESCRIPTION
Makes 1GE100 adder performance match castor's
Changes delay scaling approach to touch xbar and cb only
Adds DSP numbers from openfpga-pd-castor-rs PR 439 (scaled to 0.85v)
