### PR TITLE
Fetch xml workflow Improvements

### DIFF
--- a/.github/workflows/fetch_xml.yml
+++ b/.github/workflows/fetch_xml.yml
@@ -1,7 +1,7 @@
 name: 'Fetch and Test XML changes'
 
 on:
-  push:
+  #push:
   repository_dispatch:
     types: [digest_latest_Arch]
 
@@ -48,9 +48,9 @@ jobs:
 
     - name:  checkout tag and copy Arch files
       run: |
-          #echo "payload: ${{ github.event.client_payload.new_tag }}"
+          echo "payload: ${{ github.event.client_payload.new_tag }}"
+          cd openfpga-pd-castor-rs && git checkout ${{ github.event.client_payload.new_tag }} && cd - && bash .github/copy_arch.sh
           #cd openfpga-pd-castor-rs && git checkout ${{ github.event.client_payload.new_tag }} && cd - && bash .github/copy_arch.sh
-          cd openfpga-pd-castor-rs && git checkout v1.6.25 && cd - && bash .github/copy_arch.sh
 
     - name: Check changes are XML related
       id: xml_change
@@ -70,18 +70,18 @@ jobs:
       with:
         email: nadeem.yaseen@rapidsilicon.com
         name: nadeemyaseen-rs
-        commit_message: Added XMLs files from v1.6.25
+        commit_message: Added XMLs files from ${{ github.event.client_payload.new_tag }}
         files: "*.xml"
-        target_branch: xml_v1.6.25
+        target_branch: xml_${{ github.event.client_payload.new_tag }}
 
 # if above step pass then create PR.          
     - name: Create PR
       if: contains(steps.xml_change.outputs.xml_changed, 'true')
       uses: repo-sync/pull-request@v2
       with:
-          source_branch: xml_v1.6.25                                # branch having xmls files
+          source_branch: xml_${{ github.event.client_payload.new_tag }}                                # branch having xmls files
           destination_branch: "main"                                                                   # name of branch on which PR go
-          pr_title: "Pulling XMLs v1.6.25 into main. "               # Title of pull request
+          pr_title: "Pulling XMLs ${{ github.event.client_payload.new_tag }} into main. "               # Title of pull request
           pr_body: "An automated PR to checkin New XMLs tag. Click on link to see tests/batch results ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"                              # Full markdown support, requires pr_title
           pr_reviewer: "alain-rs"                                                         # Comma-separated list (no spaces)
           pr_assignee: "nadeemyaseen-rs"                                                  # Comma-separated list (no spaces)


### PR DESCRIPTION
In past, the XML fetch workflow fails when changes are not related to XMLs. So a check is added which will make sure we only proceed when changes are related to XML files else just skip the push and PR create step.

In case we have changes then example output: https://github.com/RapidSilicon/Raptor/actions/runs/4514557840/jobs/7950782568#step:7:15