### PR TITLE
Use qt artifact from last main branch run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,7 +216,7 @@ jobs:
         search_artifacts: true
         github_token: ${{ secrets.QT_DOWNLOAD }}
         repo: ${{ github.repository }}
-        run_number: 2555
+        #run_number: 2555
         skip_unpack: true
         branch: main
         #workflow_conclusion: success


### PR DESCRIPTION
Instead of using artifacts from a specific run number, use from the main branch's last uploaded one.