### PR TITLE
Add the openocd exec bin path

### DIFF
--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -87,6 +87,7 @@ int main(int argc, char** argv) {
     std::filesystem::path repackConstraintPath = datapath / "etc" / "devices" /
                                                  "gemini" /
                                                  "repack_design_constraint.xml";
+    std::filesystem::path openOcdPath = binpath / "openocd";
     opcompiler->AnalyzeExecPath(analyzePath);
     opcompiler->YosysExecPath(yosysPath);
     opcompiler->VprExecPath(vprPath);
@@ -97,6 +98,7 @@ int main(int argc, char** argv) {
     opcompiler->OpenFpgaSimSettingFile(simSettingPath);
     opcompiler->OpenFpgaRepackConstraintsFile(repackConstraintPath);
     opcompiler->PinConvExecPath(pinConvPath);
+    opcompiler->ProgrammerToolExecPath(openOcdPath);
     opcompiler->GetSimulator()->SetSimulatorPath(
         FOEDAG::Simulator::SimulatorType::Verilator,
         (binpath / "HDL_simulator" / "verilator" / "bin").string());
@@ -106,6 +108,8 @@ int main(int argc, char** argv) {
     opcompiler->GetSimulator()->SetSimulatorPath(
         FOEDAG::Simulator::SimulatorType::Icarus,
         (binpath / "HDL_simulator" / "iverilog" / "bin").string());
+    std::filesystem::path configFileSearchDir = datapath / "configuration";
+    opcompiler->SetConfigFileSearchDirectory(configFileSearchDir);
   }
   return foedag->init(guiType);
 }


### PR DESCRIPTION
Add the openocd bin path and configuration path into Raptor main. This change was missed in the ealier implementation as I expected it from FOEDAG_rs, it turned out there is main.cpp invoking raptor GUI.

