### PR TITLE
Runner storage shortage workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,13 +94,26 @@ jobs:
         which $CC && $CC --version
         which $CXX && $CXX --version
 
+    - name: free disk space
+      run: |
+        du -sch *
+        df -h
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        sudo apt-get autoremove -y >/dev/null 2>&1
+        sudo apt-get autoclean -y >/dev/null 2>&1
+        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
+        df -h
+
     - name: Test Release
       if: matrix.mode == 'test'
       run: |
         make release ADDITIONAL_CMAKE_OPTIONS=-DBUILD_YOSYS_PLUGINS=ON test
         make release test/batch
         make release test/batch_gen2
-
+        
     - name: Regression
       if: matrix.mode == 'regression'
       run: |


### PR DESCRIPTION
As pointed out in [PR](https://github.com/RapidSilicon/Raptor/pull/913#issuecomment-1574654535) by @ravic-rs, we were having a shortage of storage on runners. After doing an analysis, it was found that we were having only 20GB available for build out of a total of 84 GB. Most of the space was being consumed in apt cache and docker images (pre-installed on the runner) that are not needed at all. 
So removing apt cache and docker images, the available space increased to 39GB. Now valgrind action is passing.
 