### PR TITLE
location constraint example

### DIFF
--- a/tests/Testcases/and2_verilog/and2_part.xml
+++ b/tests/Testcases/and2_verilog/and2_part.xml
@@ -1,0 +1,8 @@
+<vpr_constraints tool_name="vpr">
+         <partition_list>
+         <partition name="Part0">
+                 <add_atom name_pattern="_*"/>
+                 <add_region x_low="1" y_low="4" x_high="2" y_high="4"/>
+          </partition>
+         </partition_list>
+</vpr_constraints>

--- a/tests/Testcases/and2_verilog/run_raptor.tcl
+++ b/tests/Testcases/and2_verilog/run_raptor.tcl
@@ -38,6 +38,7 @@ puts "Compiling $project_name..."
 analyze
 synthesize delay
 simulate gate icarus
+pnr_options --read_vpr_constraints and2_part.xml
 packing
 place
 route


### PR DESCRIPTION
Location constraint file can be provided to VPR with partition definition and partition content definition:
https://docs.verilogtorouting.org/en/latest/vpr/placement_constraints/#constraints-file-format

Important:
  - the file has to have the .xml extension
  - the partition has to have access to IOs, else there is no way to place the design (Island in the middle does not work)
  - x=1,y=1 is the bottom left corner
  - the atom names/regexps are the gate-level netlist instance names

