### PR TITLE
changing IO delay locally

### DIFF
--- a/etc/devices/1GE100-ES1/gemini_vpr.xml
+++ b/etc/devices/1GE100-ES1/gemini_vpr.xml
@@ -966,7 +966,10 @@
           <complete name="io_output-clk" input="io.clk" output="io_output.clk">      
                   
                </complete>
-          <direct name="io_output-f2a_i" input="io.f2a_i" output="io_output.f2a_i"/>
+               <direct name="io_output-f2a_i" input="io.f2a_i" output="io_output.f2a_i">
+                <delay_constant max="7.10e-10" min="5.00e-10" in_port="io.f2a_i" out_port="io_output.f2a_i" />
+              </direct>
+          <!-- <direct name="io_output-f2a_i" input="io.f2a_i" output="io_output.f2a_i"/> -->
         </interconnect>
       </mode>
       <mode name="io_input">
@@ -1029,7 +1032,12 @@
           </interconnect>
         </pb_type>
         <interconnect>
-          <direct name="io-a2f_o" input="io_input.a2f_o" output="io.a2f_o"/>
+
+          <direct name="io-a2f_o" input="io_input.a2f_o" output="io.a2f_o">
+            <delay_constant max="8.40e-10" min="7.60e-10" in_port="io_input.a2f_o" out_port="io.a2f_o"/>
+          </direct>
+          
+          <!-- <direct name="io-a2f_o" input="io_input.a2f_o" output="io.a2f_o"/> -->
           <complete name="io_input-clk" input="io.clk" output="io_input.clk">      
                   
                </complete>


### PR DESCRIPTION
I added the local changes to the architecture as you mentioned. However, I see that there are some cases the constant delays are added to the "physical mode" in addition to  the logical mode. Perhaps we may add this constant delay to the physical mode.