### PR TITLE
fixed and re-enabled pin_c testcases to match new PT

### DIFF
--- a/tests/Testcases/and2_compact/pin_mapping.pin
+++ b/tests/Testcases/and2_compact/pin_mapping.pin
@@ -1,10 +1,10 @@
 
-#set_property mode Mode_BP_SDR_A_RX HP_3_0_0P
-#set_pin_loc a HP_3_0_0P
+set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
+set_pin_loc a HR_3_0_0P
 
 set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
 set_pin_loc b HR_2_0_0P
 
-#set_property mode  Mode_BP_SDR_A_TX HR_4_20_10P
-#set_pin_loc c HR_4_20_10P
+set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
+set_pin_loc c HR_5_0_0P
 

--- a/tests/Testcases/and2_reg/pin_mapping.pin
+++ b/tests/Testcases/and2_reg/pin_mapping.pin
@@ -1,11 +1,11 @@
 set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
 set_pin_loc reg_a HR_2_0_0P
 
-#set_property mode Mode_BP_SDR_A_RX HP_1_26_13P
-#set_pin_loc reg_b HP_1_26_13P
+set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
+set_pin_loc reg_b HR_3_0_0P
 
-#set_property mode  Mode_BP_SDR_A_TX HP_1_24_12P
-#set_pin_loc Q HP_1_24_12P
+set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
+set_pin_loc Q HR_5_0_0P
 
 set_clock_pin -device_clock clk[8] -design_clock clki
 set_clock_pin -device_clock clk[9] -design_clock clko

--- a/tests/Testcases/and2_repack_constraints/pin_mapping.pin
+++ b/tests/Testcases/and2_repack_constraints/pin_mapping.pin
@@ -1,11 +1,11 @@
 set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
 set_pin_loc reg_a HR_2_0_0P
 
-#set_property mode Mode_BP_SDR_A_RX HP_1_26_13P
-#set_pin_loc reg_b HP_1_26_13P
+set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
+set_pin_loc reg_b HR_3_0_0P
 
-#set_property mode  Mode_BP_SDR_A_TX HP_1_24_12P
-#set_pin_loc Q HP_1_24_12P
+set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
+set_pin_loc Q HR_5_0_0P
 
 set_clock_pin -device_clock clk[8] -design_clock clki
 set_clock_pin -device_clock clk[9] -design_clock clko

--- a/tests/Testcases/and2_verilog/pin_mapping.pin
+++ b/tests/Testcases/and2_verilog/pin_mapping.pin
@@ -1,10 +1,10 @@
 
-#set_property mode Mode_BP_SDR_A_RX HP_3_0_0P
-#set_pin_loc a HP_3_0_0P
+set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
+set_pin_loc a HR_3_0_0P
 
 set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
 set_pin_loc b HR_2_0_0P
 
-#set_property mode  Mode_BP_SDR_A_TX HR_4_20_10P
-#set_pin_loc c HR_4_20_10P
+set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
+set_pin_loc c HR_5_0_0P
 

--- a/tests/Testcases/counter16/pin_mapping.pin
+++ b/tests/Testcases/counter16/pin_mapping.pin
@@ -1,10 +1,10 @@
 
-#set_property mode Mode_BP_SDR_A_RX HP_3_0_0P
-#set_pin_loc a HP_3_0_0P
+set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
+set_pin_loc clock0 HR_3_0_0P
 
 set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
 set_pin_loc reset HR_2_0_0P
 
-#set_property mode  Mode_BP_SDR_A_TX HR_4_20_10P
-#set_pin_loc c HR_4_20_10P
+set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
+set_pin_loc {q[0]} HR_5_0_0P
 

--- a/tests/Testcases/partitioner_and2_verilog/pin_mapping.pin
+++ b/tests/Testcases/partitioner_and2_verilog/pin_mapping.pin
@@ -1,10 +1,10 @@
 
-#set_property mode Mode_BP_SDR_A_RX HP_3_0_0P
-#set_pin_loc a HP_3_0_0P
+set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
+set_pin_loc a HR_3_0_0P
 
 set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
 set_pin_loc b HR_2_0_0P
 
-#set_property mode  Mode_BP_SDR_A_TX HR_4_20_10P
-#set_pin_loc c HR_4_20_10P
+set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
+set_pin_loc c HR_5_0_0P
 


### PR DESCRIPTION
When  gemini_compact_10x8/Virgo_Pin_Table.csv was created and these tests switched to this new PT, some device pin references became invalid (not present in the new PT).
This fix updates pin references to be valid.