### PR TITLE
Update pin_mapping.pin for testcase and2

### DIFF
--- a/tests/Testcases/and2_verilog/pin_mapping.pin
+++ b/tests/Testcases/and2_verilog/pin_mapping.pin
@@ -1,10 +1,6 @@
-
-set_property mode Mode_BP_SDR_A_RX HR_3_0_0P
-set_pin_loc a HR_3_0_0P
-
-set_property mode Mode_BP_SDR_A_RX HR_2_0_0P
-set_pin_loc b HR_2_0_0P
-
-set_property mode  Mode_BP_SDR_A_TX HR_5_0_0P
-set_pin_loc c HR_5_0_0P
-
+set_pin_loc a HR_1_0_0P g2f_rx_in[0]_A
+set_pin_loc b HR_2_0_0P g2f_rx_in[0]_A
+set_pin_loc c HR_5_0_0P f2g_tx_out[0]_A
+set_mode MODE_BP_SDR_A_RX HR_1_0_0P
+set_mode MODE_BP_SDR_A_RX HR_2_0_0P
+set_mode MODE_BP_SDR_A_TX HR_5_0_0P


### PR DESCRIPTION
As suggested by George in [EDA-2310](https://rapidsilicon.atlassian.net/browse/EDA-2310), the release 0.9.16 is failing because of choosing the wrong pins so updating the test case. 

[EDA-2310]: https://rapidsilicon.atlassian.net/browse/EDA-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ