### PR TITLE
Fixed migration. Version should stay 0.8.55

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,8 @@ else()
 endif()
 message(STATUS "The version is ::: ${RELEASE_VERSION}")
 set(VERSION_MAJOR_COM 0)
-set(VERSION_MINOR_COM 9)
-set(VERSION_PATCH_COM 24)
+set(VERSION_MINOR_COM 8)
+set(VERSION_PATCH_COM 55)
 configure_file(raptor_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/FOEDAG_rs/FOEDAG/include/foedag_version.h)
 
 # Require swig 3

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test_install:
 test/gui: 
 	$(XVFB) ./dbuild/bin/raptor --compiler dummy --replay tests/TestGui/gui_foedag.tcl
 	$(XVFB) ./dbuild/bin/raptor --script tests/TestGui/gtkwave_cmds.tcl || (cat raptor.log; exit 1)
-# This test is broken	$(XVFB) ./dbuild/bin/raptor --script tests/TestGui/gui_run_incr_comp_project.tcl
+	$(XVFB) ./dbuild/bin/raptor --script tests/TestGui/gui_run_incr_comp_project.tcl
 
 test/rs: run-cmake-release
 	./build/bin/raptor --batch --script tests/Testcases/aes_decrypt_fpga/aes_decrypt.tcl


### PR DESCRIPTION
Version for migration is 0.8.55
tests/TestGui/gui_run_incr_comp_project.tcl stuck because of message from GUI.