### PR TITLE
Update to_be_raptor_linx to add default location of license file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ if (PRODUCTION_BUILD)
          REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
   add_subdirectory(${OPENLM_DIR} OPENLM_DIR)
   message(STATUS "OPENLM_DIR: "  ${OPENLM_DIR})
+  #dump openlm license file env variable default value
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/etc/config.json" JSON_DATA)
+  string(JSON prefixPath GET ${JSON_DATA} general license-path)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/bin/default_lic_path" "default_path=${prefixPath}\n")
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/bin/default_lic_path" "export LICENSE_LOCATION=$default_path\\;$LICENSE_LOCATION")
 endif()
 
 

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -9,7 +9,7 @@ SCRIPT_PATH=`dirname $BASH_SOURCE`
 RAPTOR_PATH=`( cd "$SCRIPT_PATH" && pwd )`
 
 [ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/../.raptorenv_lin64.sh
-[ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/default_lic_path
+[ -f $RAPTOR_PATH/default_lic_path ] && source $RAPTOR_PATH/default_lic_path
 
 if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
     $RAPTOR_PATH/bin/raptor.exe "$@"

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -9,8 +9,7 @@ SCRIPT_PATH=`dirname $BASH_SOURCE`
 RAPTOR_PATH=`( cd "$SCRIPT_PATH" && pwd )`
 
 [ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/../.raptorenv_lin64.sh
-
-export LICENSE_LOCATION=$HOME/.local/Rapidsilicon/raptor.lic\;$LICENSE_LOCATION
+[ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/default_lic_path
 
 if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
     $RAPTOR_PATH/bin/raptor.exe "$@"

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -10,6 +10,8 @@ RAPTOR_PATH=`( cd "$SCRIPT_PATH" && pwd )`
 
 [ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/../.raptorenv_lin64.sh
 
+export LICENSE_LOCATION=$HOME/.local/Rapidsilicon/raptor.lic\;$LICENSE_LOCATION
+
 if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
     $RAPTOR_PATH/bin/raptor.exe "$@"
 else


### PR DESCRIPTION
In GUI, we already have the option to copy the license file to the $HOME/.local/Rapidsilicon location with the name raptor.lic.
In the wrapper script, setting this path as the value of the LICENSE_LOCATION variable will make raptor.exe find the license file easily. 