### PR TITLE
Install the file having default license path env variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -733,6 +733,11 @@ if (PRODUCTION_BUILD)
           ${CMAKE_CURRENT_SOURCE_DIR}/Raptor_Tools/OpenLM/licensecc/install/bin/Raptor/lccinspector
       DESTINATION ${CMAKE_INSTALL_BINDIR}/OpenLM
   )
+  install(
+      PROGRAMS
+          ${CMAKE_CURRENT_BINARY_DIR}/bin/default_lic_path
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
 endif()
 
 install(

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -9,7 +9,7 @@ SCRIPT_PATH=`dirname $BASH_SOURCE`
 RAPTOR_PATH=`( cd "$SCRIPT_PATH" && pwd )`
 
 [ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/../.raptorenv_lin64.sh
-[ -f $RAPTOR_PATH/default_lic_path ] && source $RAPTOR_PATH/default_lic_path
+[ -f $RAPTOR_PATH/bin/default_lic_path ] && source $RAPTOR_PATH/bin/default_lic_path
 
 if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
     $RAPTOR_PATH/bin/raptor.exe "$@"


### PR DESCRIPTION
On execution of the CMake install target, copy the file having the license file environment variable 