### PR TITLE
Backend: build libPlanner_dll.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,10 +273,10 @@ if(NOT NO_TCMALLOC)
   endif()
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" CACHE STRING "-fPIC" FORCE)
+
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} ${TCMALLOC_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" CACHE STRING "-fPIC" FORCE)
 
 if(MSVC)
   add_subdirectory(third_party/zlib) # Do not use EXCLUDE_FROM_ALL else unit tests will fail for this subsystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,8 @@ endif()
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} ${TCMALLOC_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" CACHE STRING "-fPIC" FORCE)
+
 if(MSVC)
   add_subdirectory(third_party/zlib) # Do not use EXCLUDE_FROM_ALL else unit tests will fail for this subsystem
 


### PR DESCRIPTION
Syncing current Backend. There are no functional changes.
Backend now builds build/stars/libPlanner_dll.so

@NadeemYaseen , after this PR is merged, please update Raptor makefiles to copy libPlanner_dll.so to Raptor/build/bin/
directory, the same way as pin_c, stars, vpr binaries are copied. Let's consider it as another Backend binary.
