### PR TITLE
In production mode, in GH CI, build two raptor exe, one with Monaco and one with QScintilla

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,6 +345,7 @@ jobs:
             d_test=$(echo "$p_device" | cut -d ',' -f 1)
             mkdir /opt/instl_dir
             make install CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
+            make install MONACO_EDITOR=0 CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
             #export LM_LICENSE_FILE=/work/.github/bin/.raptor.lic
             ./Raptor_Tools/OpenLM/licensecc/install/bin/lccgen license issue -p projects/Raptor -f Raptor,$d_test,DE -o build/bin/raptor.lic
             cat build/bin/raptor.lic

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,8 +364,8 @@ jobs:
 # The below section upload Raptor binaries to FTP so to enable it make sure provide your credentials.
     - name: Check FTP server status
       # Change ref head to deploy using a different branch.
-      #if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
-      if: "${{ matrix.mode == 'production' }}"
+      if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
+      #if: "${{ matrix.mode == 'production' }}"
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.FTP_IP }}
@@ -376,8 +376,8 @@ jobs:
 
     - name: Deploy
       # Change ref head to deploy using a different branch.
-      #if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
-      if: "${{ matrix.mode == 'production'}}"
+      if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
+      #if: "${{ matrix.mode == 'production'}}"
       uses: appleboy/scp-action@master
       with:
          host: ${{ secrets.FTP_IP }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,8 +364,8 @@ jobs:
 # The below section upload Raptor binaries to FTP so to enable it make sure provide your credentials.
     - name: Check FTP server status
       # Change ref head to deploy using a different branch.
-      if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
-      #if: "${{ matrix.mode == 'production' }}"
+      #if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
+      if: "${{ matrix.mode == 'production' }}"
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.FTP_IP }}
@@ -376,8 +376,8 @@ jobs:
 
     - name: Deploy
       # Change ref head to deploy using a different branch.
-      if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
-      #if: "${{ matrix.mode == 'production'}}"
+      #if: "${{ matrix.mode == 'production' && github.ref == 'refs/heads/main' && env.FORK_REPO  == 'ON' }}"
+      if: "${{ matrix.mode == 'production'}}"
       uses: appleboy/scp-action@master
       with:
          host: ${{ secrets.FTP_IP }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,14 +627,23 @@ install(
         ${CMAKE_CURRENT_BINARY_DIR}/FOEDAG_rs/FOEDAG/include/tclPlatDecls.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/raptor/include)
 
-install(
+if(MONACO_EDITOR)  
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/raptorMonacoEmbed.exe
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PERMISSIONS
+    OWNER_READ OWNER_EXECUTE OWNER_WRITE
+    GROUP_READ GROUP_EXECUTE
+    WORLD_READ WORLD_EXECUTE)
+else()
+  install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exe
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     PERMISSIONS
     OWNER_READ OWNER_EXECUTE OWNER_WRITE
     GROUP_READ GROUP_EXECUTE
     WORLD_READ WORLD_EXECUTE)
-
+endif()
 install(
     DIRECTORY etc/ DESTINATION  ${CMAKE_INSTALL_DATAROOTDIR}/raptor/etc/)
 install(
@@ -890,11 +899,19 @@ else ()
       COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_CURRENT_BINARY_DIR}/Backend/stars/stars
         ${CMAKE_CURRENT_BINARY_DIR}/bin/)
-  add_custom_command(TARGET raptor-bin POST_BUILD
-        COMMAND echo "rename raptor binary as raptor.exe"
-        COMMAND ${CMAKE_COMMAND} -E rename
-          ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor
-          ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exe)
+  if(MONACO_EDITOR)      
+    add_custom_command(TARGET raptor-bin POST_BUILD
+          COMMAND echo "rename raptor binary as raptorMonacoEmbed.exe"
+          COMMAND ${CMAKE_COMMAND} -E rename
+            ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor
+            ${CMAKE_CURRENT_BINARY_DIR}/bin/raptorMonacoEmbed.exe)
+  else()
+    add_custom_command(TARGET raptor-bin POST_BUILD
+    COMMAND echo "rename raptor binary as raptor.exe"
+    COMMAND ${CMAKE_COMMAND} -E rename
+      ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor
+      ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exe)
+  endif()
   add_custom_command(TARGET raptor-bin POST_BUILD
         COMMAND echo "copy to_be_raptor_lnx as raptor"
         COMMAND ${CMAKE_COMMAND} -E copy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,7 +629,7 @@ install(
 
 if(MONACO_EDITOR)  
   install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/raptorMonacoEmbed.exe
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exeMonacoEmbed
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     PERMISSIONS
     OWNER_READ OWNER_EXECUTE OWNER_WRITE
@@ -901,10 +901,10 @@ else ()
         ${CMAKE_CURRENT_BINARY_DIR}/bin/)
   if(MONACO_EDITOR)      
     add_custom_command(TARGET raptor-bin POST_BUILD
-          COMMAND echo "rename raptor binary as raptorMonacoEmbed.exe"
+          COMMAND echo "rename raptor binary as raptor.exeMonacoEmbed"
           COMMAND ${CMAKE_COMMAND} -E rename
             ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor
-            ${CMAKE_CURRENT_BINARY_DIR}/bin/raptorMonacoEmbed.exe)
+            ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exeMonacoEmbed)
   else()
     add_custom_command(TARGET raptor-bin POST_BUILD
     COMMAND echo "rename raptor binary as raptor.exe"

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -12,10 +12,31 @@ RAPTOR_EXE_DEBUG=1
 [ -f $RAPTOR_PATH/../.raptorenv_lin64.sh ] && source $RAPTOR_PATH/../.raptorenv_lin64.sh
 [ -f $RAPTOR_PATH/bin/default_lic_path ] && source $RAPTOR_PATH/bin/default_lic_path
 
-if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
-    $RAPTOR_PATH/bin/raptor.exe "$@"
+# Function to detect the environment
+detect_environment() {
+    # Check if running inside WSL
+    if grep -q Microsoft /proc/version; then
+        echo "WSL"
+    # Check if running inside Docker
+    elif [ -f "/.dockerenv" ]; then
+        echo "Docker"
+    # Assume native Linux
+    else
+        echo "Native"
+    fi
+}
+
+environment=$(detect_environment)
+if [ "$environment" == "Native" ]; then
+        RAPTOR_EXE=raptorMonacoEmbed.exe
 else
-    $RAPTOR_PATH/bin/raptor.exe "$@" 2>/dev/null
+        RAPTOR_EXE=raptor.exe
+fi
+
+if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
+    $RAPTOR_PATH/bin/$RAPTOR_EXE "$@"
+else
+    $RAPTOR_PATH/bin/$RAPTOR_EXE "$@" 2>/dev/null
 fi
 
 

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -28,10 +28,13 @@ detect_environment() {
 
 environment=$(detect_environment)
 if [ "$environment" == "Native" ]; then
-        RAPTOR_EXE=raptorMonacoEmbed.exe
+        RAPTOR_EXE=raptor.exeMonacoEmbed
 else
         RAPTOR_EXE=raptor.exe
 fi
+
+# Uncomment below in case if above condition are not working as expected
+#RAPTOR_EXE=raptor.exe
 
 if [[ "$RAPTOR_EXE_DEBUG" == "1"   ]]; then
     $RAPTOR_PATH/bin/$RAPTOR_EXE "$@"


### PR DESCRIPTION
In the Docker or WSL environment, we currently don't support Monaco Editor. So in production mode, build two Raptor executables, one with Monaco Editor and one with QScintilla. While invoking the executable, do your best to detect the environment and invoke the respected binary. 