### PR TITLE
Disable IPA build in MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ADDITIONAL_CMAKE_OPTIONS ?=
 # make MONACO_EDITOR=0 enables the QScintilla based Editor in place of the WebEngine based Monaco Editor
 MONACO_EDITOR ?= 1
 
-IPA ?= 1
+IPA ?= 0
 
 # If 'on', then the progress messages are printed. If 'off', makes it easier
 # to detect actual warnings and errors  in the build output.


### PR DESCRIPTION
- We want to build this only at foedag and foedag_rs for code. Refer: https://github.com/os-fpga/FOEDAG/issues/1479#issuecomment-2015425353

- This feature will not work with Raptor so better to leave it disabled until VPR has the relevant updates.
https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/2483

