### PR TITLE
Install Python 3.8 on CentOS 7

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -7,7 +7,7 @@ ENV CC=/opt/rh/devtoolset-11/root/usr/bin/gcc
 ENV CXX=/opt/rh/devtoolset-11/root/usr/bin/g++
 ENV QMAKE_CC='/opt/rh/devtoolset-11/root/usr/bin/gcc'
 ENV QMAKE_CXX='/opt/rh/devtoolset-11/root/usr/bin/g++'
-ENV PATH="/usr/local/Qt6.2.4/bin:/usr/lib/ccache:$PATH"
+ENV PATH="/opt/python3.8/bin:/usr/local/Qt6.2.4/bin:/usr/lib/ccache:$PATH"
 ENV PREFIX=/tmp/raptor_gui-install
 ENV ADDITIONAL_CMAKE_OPTIONS='-DMY_CXX_WARNING_FLAGS="-W -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Werror -UNDEBUG"'
 ENV RULE_MESSAGES=off

--- a/.github/workflows/install_centos_dependencies_build.sh
+++ b/.github/workflows/install_centos_dependencies_build.sh
@@ -70,5 +70,11 @@ curl -L https://github.com/os-fpga/post_build_artifacts/releases/download/v0.2/q
 tar -xzf qt-for-centos7.tar.gz
 mv Qt6.2.4 /usr/local/
 yum clean all
+
+wget https://github.com/os-fpga/post_build_artifacts/releases/download/v0.1/python3.8_static_zlib_8march_2023.tar.gz -O python.tar.gz
+tar -xzf python.tar.gz
+mv python3.8 /opt
+rm /opt/python3.8/bin/python3 && ln -sf /opt/python3.8/bin/python3.8 /opt/python3.8/bin/python3
+
 rm -rf qt-for-centos7.tar.gz
 


### PR DESCRIPTION
Install Python 3.8 on CentOS 7 so that CFG system can use it