### PR TITLE
Fix Production build incremental compilation error 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,6 +345,7 @@ jobs:
             d_test=$(echo "$p_device" | cut -d ',' -f 1)
             mkdir /opt/instl_dir
             make install CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
+            make clean
             make install MONACO_EDITOR=0 CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
             #export LM_LICENSE_FILE=/work/.github/bin/.raptor.lic
             ./build/OPENLM_DIR/licensecc/extern/license-generator/src/license_generator/lccgen license issue -p projects/Raptor -f Raptor,$d_test,DE -o build/bin/raptor.lic


### PR DESCRIPTION
When doing make install for production build incrementally then do make clean once before doing make install again to fix the error of "not found QtWebenginePage"