### PR TITLE
In CentOS 7 production build compile only FOEDAG

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,7 +345,7 @@ jobs:
             d_test=$(echo "$p_device" | cut -d ',' -f 1)
             mkdir /opt/instl_dir
             make install CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
-            make clean
+            echo "2nd compilation"
             make install MONACO_EDITOR=0 CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
             #export LM_LICENSE_FILE=/work/.github/bin/.raptor.lic
             ./build/OPENLM_DIR/licensecc/extern/license-generator/src/license_generator/lccgen license issue -p projects/Raptor -f Raptor,$d_test,DE -o build/bin/raptor.lic

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -346,6 +346,7 @@ jobs:
             mkdir /opt/instl_dir
             make install CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
             echo "2nd compilation"
+            rm -rvf build/FOEDAG_rs
             make install MONACO_EDITOR=0 CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
             #export LM_LICENSE_FILE=/work/.github/bin/.raptor.lic
             ./build/OPENLM_DIR/licensecc/extern/license-generator/src/license_generator/lccgen license issue -p projects/Raptor -f Raptor,$d_test,DE -o build/bin/raptor.lic


### PR DESCRIPTION
To build Raptor exe without Monaco Editor after doing the make install then remove the FOEDAG folder from the build folder and start the make install again with MONACO_EIDTOR=0