### PR TITLE
Port latest FOEDAG_rs + Update IO Config Map

### DIFF
--- a/src/ConfigurationRaptor/CFGDeviceDatabase/Gemini/config_attributes.mapping.json
+++ b/src/ConfigurationRaptor/CFGDeviceDatabase/Gemini/config_attributes.mapping.json
@@ -43,6 +43,19 @@
         "O_DDR" : "MODE==DDR"
       }
     },
+    "BOOT_CLOCK" : {
+      "rules" : {
+        "ROUTE_TO_FABRIC_CLK" : "__arg0__"
+      },
+      "results" : {
+        "__other__" : [
+          {
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg0__",
+            "ROOT_MUX_SEL" : "48"
+          }
+        ]
+      }
+    },
     "PLL.PLLREF_MUX" : {
       "rules" : {
         "__location__" : "__arg0__"
@@ -50,8 +63,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux___pll_resource__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux___pll_resource__",
             "cfg_pllref_hv_rx_io_sel" : "__cfg_pllref_hv_rx_io_sel__",
             "cfg_pllref_hv_bank_rx_io_sel" : "__cfg_pllref_hv_bank_rx_io_sel__",
             "cfg_pllref_hp_rx_io_sel" : "__cfg_pllref_hp_rx_io_sel__",
@@ -72,8 +84,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF___pll_resource__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF___pll_resource__",
             "__define__" : "parse_pll_parameter",
             "PLL" : "PLL_SRC==DEFAULT",
             "pll_REFDIV" : "__refdiv__",
@@ -93,8 +104,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux0",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -109,8 +119,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux1",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -125,8 +134,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux2",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -141,8 +149,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux3",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -233,7 +240,7 @@
         "__other__" : [
           {
             "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux___stype_____bank__",
+            "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux___bank__",
             "CDR_CLK_ROOT_SEL_B" : "__CDR_CLK_ROOT_SEL_B__",
             "CDR_CLK_ROOT_SEL_A" : "__CDR_CLK_ROOT_SEL_A__",
             "CORE_CLK_ROOT_SEL_B" : "__CORE_CLK_ROOT_SEL_B__",
@@ -250,8 +257,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "ROOT_MUX_SEL" : "__ROOT_MUX_SEL__"
           }
         ]
@@ -261,6 +267,7 @@
   "__init__" : {
     "__args__" : [],
     "__equation__" : [
+      "MAX_BOOT_CLOCK_RESOURCE = 1",
       "MAX_FABRIC_CLOCK_RESOURCE = 16",
       "MAX_PLL_RESOURCE = 2",
       "hp_banks = ['HP_%d' % i for i in [1, 2]]",
@@ -268,16 +275,18 @@
       "all_banks = hp_banks + hr_banks",
       "pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in range(40)]",
       "cc_pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in [10, 11, 28, 29]]",
+      "print(cc_pin_list)",
       "cc_p_pin_list = [pin for pin in cc_pin_list if pin[-1] == 'P']",
       "g_all_pins = ['%s_%s%s' % (i, 'CC_' if j in cc_pin_list else '', j) for i in all_banks for j in pin_list]",
       "g_all_clock_pins = ['%s_CC_%s' % (i, j) for i in all_banks for j in cc_p_pin_list]",
       "g_all_pll_clock_pins = [pin for pin in g_all_clock_pins]",
+      "g_boot_clock_resources = 0",
       "g_pin_resources = []",
       "g_fabric_clock_resources = 0",
       "g_pll_resources = []"
     ]
   },
-  "__location_validation__" : {
+  "__primary_validation__" : {
     "__seqeunce__" : [
       "__pin_is_valid__",
       "__check_pin_resource__",
@@ -285,6 +294,7 @@
       "__pin_is_differential__",
       "__check_ds_pin_resource__",
       "__clock_pin_is_valid__",
+      "__check_boot_clock_resource__",
       "__pll_clock_pin_is_valid__"
     ],
     "__pin_is_valid__" : {
@@ -344,14 +354,22 @@
         "pin_result = '__location0__' in g_all_clock_pins"
       ]
     },
+    "__check_boot_clock_resource__" : {
+      "__module__" : ["BOOT_CLOCK"],
+      "__equation__" : [
+        "pin_result = g_boot_clock_resources < MAX_BOOT_CLOCK_RESOURCE",
+        "g_boot_clock_resources += (1 if pin_result else 0)"
+      ]
+    },
     "__pll_clock_pin_is_valid__" : {
       "__module__" : ["PLL"],
+      "pre_primitive" : "CLK_BUF",
       "__equation__" : [
         "pin_result = '__location0__' in g_all_pll_clock_pins"
       ]
     }
   },
-  "__validation__" : {
+  "__secondary_validation__" : {
     "__seqeunce__" : [
       "__check_fabric_clock_resource__",
       "__check_pll_parameter__",
@@ -401,13 +419,12 @@
   },
   "__define__" : {
     "parse_location" : {
-      "__args__" : ["__type__", "__stype__", "__bank__"],
+      "__args__" : ["__type__", "__bank__"],
       "__equation__" : [
         "import re",
         "assert '__location__' in g_all_pins",
         "m = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location__')",
         "__type__ = 'HP' if m.group(1) == 'P' else 'HV'",
-        "__stype__ = __type__.lower()",
         "__bank__ = '0' if m.group(2) in ['1', '3'] else '1'"
       ]
     },

--- a/src/ConfigurationRaptor/CFGDeviceDatabase/Gemini/config_attributes.mapping.json
+++ b/src/ConfigurationRaptor/CFGDeviceDatabase/Gemini/config_attributes.mapping.json
@@ -275,7 +275,6 @@
       "all_banks = hp_banks + hr_banks",
       "pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in range(40)]",
       "cc_pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in [10, 11, 28, 29]]",
-      "print(cc_pin_list)",
       "cc_p_pin_list = [pin for pin in cc_pin_list if pin[-1] == 'P']",
       "g_all_pins = ['%s_%s%s' % (i, 'CC_' if j in cc_pin_list else '', j) for i in all_banks for j in pin_list]",
       "g_all_clock_pins = ['%s_CC_%s' % (i, j) for i in all_banks for j in cc_p_pin_list]",

--- a/src/ConfigurationRaptor/CFGDeviceDatabase/Virgo/config_attributes.mapping.json
+++ b/src/ConfigurationRaptor/CFGDeviceDatabase/Virgo/config_attributes.mapping.json
@@ -43,6 +43,19 @@
         "O_DDR" : "MODE==DDR"
       }
     },
+    "BOOT_CLOCK" : {
+      "rules" : {
+        "ROUTE_TO_FABRIC_CLK" : "__arg0__"
+      },
+      "results" : {
+        "__other__" : [
+          {
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg0__",
+            "ROOT_MUX_SEL" : "48"
+          }
+        ]
+      }
+    },
     "PLL.PLLREF_MUX" : {
       "rules" : {
         "__location__" : "__arg0__"
@@ -50,8 +63,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux___pll_resource__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux___pll_resource__",
             "cfg_pllref_hv_rx_io_sel" : "__cfg_pllref_hv_rx_io_sel__",
             "cfg_pllref_hv_bank_rx_io_sel" : "__cfg_pllref_hv_bank_rx_io_sel__",
             "cfg_pllref_hp_rx_io_sel" : "__cfg_pllref_hp_rx_io_sel__",
@@ -72,8 +84,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF___pll_resource__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF___pll_resource__",
             "__define__" : "parse_pll_parameter",
             "PLL" : "PLL_SRC==DEFAULT",
             "pll_REFDIV" : "__refdiv__",
@@ -93,8 +104,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux0",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -109,8 +119,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux1",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -125,8 +134,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux2",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -141,8 +149,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux3",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -233,7 +240,7 @@
         "__other__" : [
           {
             "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux___stype_____bank__",
+            "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux___bank__",
             "CDR_CLK_ROOT_SEL_B" : "__CDR_CLK_ROOT_SEL_B__",
             "CDR_CLK_ROOT_SEL_A" : "__CDR_CLK_ROOT_SEL_A__",
             "CORE_CLK_ROOT_SEL_B" : "__CORE_CLK_ROOT_SEL_B__",
@@ -250,8 +257,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "ROOT_MUX_SEL" : "__ROOT_MUX_SEL__"
           }
         ]
@@ -261,23 +267,25 @@
   "__init__" : {
     "__args__" : [],
     "__equation__" : [
+      "MAX_BOOT_CLOCK_RESOURCE = 1",
       "MAX_FABRIC_CLOCK_RESOURCE = 16",
       "MAX_PLL_RESOURCE = 2",
       "hp_banks = ['HP_%d' % i for i in [1, 2]]",
       "hr_banks = ['HR_%d' % i for i in [1, 2, 3, 5]]",
       "all_banks = hp_banks + hr_banks",
       "pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in range(40)]",
-      "cc_pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in [10, 11, 28, 29]]",
+      "cc_pin_list = ['%d_%d%c' % (i, i//2, 'N' if i%2 else 'P') for i in [18, 19, 38, 39]]",
       "cc_p_pin_list = [pin for pin in cc_pin_list if pin[-1] == 'P']",
       "g_all_pins = ['%s_%s%s' % (i, 'CC_' if j in cc_pin_list else '', j) for i in all_banks for j in pin_list]",
       "g_all_clock_pins = ['%s_CC_%s' % (i, j) for i in all_banks for j in cc_p_pin_list]",
       "g_all_pll_clock_pins = [pin for pin in g_all_clock_pins]",
+      "g_boot_clock_resources = 0",
       "g_pin_resources = []",
       "g_fabric_clock_resources = 0",
       "g_pll_resources = []"
     ]
   },
-  "__location_validation__" : {
+  "__primary_validation__" : {
     "__seqeunce__" : [
       "__pin_is_valid__",
       "__check_pin_resource__",
@@ -285,6 +293,7 @@
       "__pin_is_differential__",
       "__check_ds_pin_resource__",
       "__clock_pin_is_valid__",
+      "__check_boot_clock_resource__",
       "__pll_clock_pin_is_valid__"
     ],
     "__pin_is_valid__" : {
@@ -344,14 +353,22 @@
         "pin_result = '__location0__' in g_all_clock_pins"
       ]
     },
+    "__check_boot_clock_resource__" : {
+      "__module__" : ["BOOT_CLOCK"],
+      "__equation__" : [
+        "pin_result = g_boot_clock_resources < MAX_BOOT_CLOCK_RESOURCE",
+        "g_boot_clock_resources += (1 if pin_result else 0)"
+      ]
+    },
     "__pll_clock_pin_is_valid__" : {
       "__module__" : ["PLL"],
+      "pre_primitive" : "CLK_BUF",
       "__equation__" : [
         "pin_result = '__location0__' in g_all_pll_clock_pins"
       ]
     }
   },
-  "__validation__" : {
+  "__secondary_validation__" : {
     "__seqeunce__" : [
       "__check_fabric_clock_resource__",
       "__check_pll_parameter__",
@@ -401,13 +418,12 @@
   },
   "__define__" : {
     "parse_location" : {
-      "__args__" : ["__type__", "__stype__", "__bank__"],
+      "__args__" : ["__type__", "__bank__"],
       "__equation__" : [
         "import re",
         "assert '__location__' in g_all_pins",
         "m = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location__')",
         "__type__ = 'HP' if m.group(1) == 'P' else 'HV'",
-        "__stype__ = __type__.lower()",
         "__bank__ = '0' if m.group(2) in ['1', '3'] else '1'"
       ]
     },

--- a/src/ConfigurationRaptor/CFGDeviceDatabase/Virgo/gemini_compact_10x8_config_attributes.mapping.json
+++ b/src/ConfigurationRaptor/CFGDeviceDatabase/Virgo/gemini_compact_10x8_config_attributes.mapping.json
@@ -43,6 +43,19 @@
         "O_DDR" : "MODE==DDR"
       }
     },
+    "BOOT_CLOCK" : {
+      "rules" : {
+        "ROUTE_TO_FABRIC_CLK" : "__arg0__"
+      },
+      "results" : {
+        "__other__" : [
+          {
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg0__",
+            "ROOT_MUX_SEL" : "48"
+          }
+        ]
+      }
+    },
     "PLL.PLLREF_MUX" : {
       "rules" : {
         "__location__" : "__arg0__"
@@ -50,8 +63,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux___pll_resource__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_pll_refmux___pll_resource__",
             "cfg_pllref_hv_rx_io_sel" : "__cfg_pllref_hv_rx_io_sel__",
             "cfg_pllref_hv_bank_rx_io_sel" : "__cfg_pllref_hv_bank_rx_io_sel__",
             "cfg_pllref_hp_rx_io_sel" : "__cfg_pllref_hp_rx_io_sel__",
@@ -72,8 +84,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF___pll_resource__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_PLLTS16FFCFRACF___pll_resource__",
             "__define__" : "parse_pll_parameter",
             "PLL" : "PLL_SRC==DEFAULT",
             "pll_REFDIV" : "__refdiv__",
@@ -93,8 +104,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux0",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -109,8 +119,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux1",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -125,8 +134,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux2",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -141,8 +149,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "__define__" : "parse_pll_root_mux3",
             "ROOT_MUX_SEL" : "__pll_root_mux_sel__"
           }
@@ -233,7 +240,7 @@
         "__other__" : [
           {
             "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux___stype_____bank__",
+            "__mapped_name__" : "__parent__.u_gbox_root_bank_clkmux___bank__",
             "CDR_CLK_ROOT_SEL_B" : "__CDR_CLK_ROOT_SEL_B__",
             "CDR_CLK_ROOT_SEL_A" : "__CDR_CLK_ROOT_SEL_A__",
             "CORE_CLK_ROOT_SEL_B" : "__CORE_CLK_ROOT_SEL_B__",
@@ -250,8 +257,7 @@
       "results" : {
         "__other__" : [
           {
-            "__name__" : "__parent__.__name__",
-            "__mapped_name__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
+            "__location__" : "u_GBOX_HP_40X2.u_gbox_clkmux_52x1_left___arg1__",
             "ROOT_MUX_SEL" : "__ROOT_MUX_SEL__"
           }
         ]
@@ -261,6 +267,7 @@
   "__init__" : {
     "__args__" : [],
     "__equation__" : [
+      "MAX_BOOT_CLOCK_RESOURCE = 1",
       "MAX_FABRIC_CLOCK_RESOURCE = 16",
       "MAX_PLL_RESOURCE = 2",
       "hp_banks = ['HP_%d' % i for i in [1]]",
@@ -272,12 +279,13 @@
       "g_all_pins = ['%s_%s%s' % (i, 'CC_' if j in cc_pin_list else '', j) for i in all_banks for j in pin_list]",
       "g_all_clock_pins = ['%s_CC_%s' % (i, j) for i in all_banks for j in cc_p_pin_list]",
       "g_all_pll_clock_pins = [pin for pin in g_all_clock_pins]",
+      "g_boot_clock_resources = 0",
       "g_pin_resources = []",
       "g_fabric_clock_resources = 0",
       "g_pll_resources = []"
     ]
   },
-  "__location_validation__" : {
+  "__primary_validation__" : {
     "__seqeunce__" : [
       "__pin_is_valid__",
       "__check_pin_resource__",
@@ -285,6 +293,7 @@
       "__pin_is_differential__",
       "__check_ds_pin_resource__",
       "__clock_pin_is_valid__",
+      "__check_boot_clock_resource__",
       "__pll_clock_pin_is_valid__"
     ],
     "__pin_is_valid__" : {
@@ -344,14 +353,22 @@
         "pin_result = '__location0__' in g_all_clock_pins"
       ]
     },
+    "__check_boot_clock_resource__" : {
+      "__module__" : ["BOOT_CLOCK"],
+      "__equation__" : [
+        "pin_result = g_boot_clock_resources < MAX_BOOT_CLOCK_RESOURCE",
+        "g_boot_clock_resources += (1 if pin_result else 0)"
+      ]
+    },
     "__pll_clock_pin_is_valid__" : {
       "__module__" : ["PLL"],
+      "pre_primitive" : "CLK_BUF",
       "__equation__" : [
         "pin_result = '__location0__' in g_all_pll_clock_pins"
       ]
     }
   },
-  "__validation__" : {
+  "__secondary_validation__" : {
     "__seqeunce__" : [
       "__check_fabric_clock_resource__",
       "__check_pll_parameter__",
@@ -401,13 +418,12 @@
   },
   "__define__" : {
     "parse_location" : {
-      "__args__" : ["__type__", "__stype__", "__bank__"],
+      "__args__" : ["__type__", "__bank__"],
       "__equation__" : [
         "import re",
         "assert '__location__' in g_all_pins",
         "m = re.search(r'H(P|R?)_(\\d?)(|_CC?)_(\\d+?)_(\\d\\d?)(P|N?)', '__location__')",
         "__type__ = 'HP' if m.group(1) == 'P' else 'HV'",
-        "__stype__ = __type__.lower()",
         "__bank__ = '0' if m.group(2) in ['1', '3'] else '1'"
       ]
     },


### PR DESCRIPTION
This change include:
   - Port latest FOEDAG_rs which include https://github.com/os-fpga/FOEDAG_rs/pull/714
   - Update IO config mapping
     - aligned with changes made in https://github.com/os-fpga/FOEDAG/pull/1558
     - support new clock capble pin in Virgo 62x44

Once this is done, we will need to port this to NS Raptor + RIC model update (manually) - then we should be able to test design that using clock. 