### PR TITLE
Keep Tribuf Synthesis option set default true

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -133,7 +133,8 @@
             "keep_tribuf": {
                 "label": "Keep Tribuf",
                 "widgetType": "checkbox",
-                "arg": "keep_tribuf"
+                "arg": "keep_tribuf",
+                "default": "checked"
             },
             "_META_": {
                 "hidden": false,


### PR DESCRIPTION
Also includes,
_EDA-2931: Fixed stop compilation when the user hits stop compilation button but the compiler has moved on to the execution of next task_