### PR TITLE
Auto Detect environment when doing make to set the MONACO_EDITOR flag value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,6 @@ release: run-cmake-release
 	cmake --build build -j $(CPU_CORES)
 endif
 
-check_monaco_editor:
-	@echo "MONACO_EDITOR is set to $(MONACO_EDITOR)"
-
 release_no_tcmalloc: run-cmake-release_no_tcmalloc
 	cmake --build build -j $(CPU_CORES)
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,19 @@ endif
 PREFIX ?= /usr/local
 ADDITIONAL_CMAKE_OPTIONS ?=
 # make MONACO_EDITOR=0 enables the QScintilla based Editor in place of the WebEngine based Monaco Editor
-MONACO_EDITOR ?= 1
+IS_WSL_OR_DOCKER := $(shell \
+    if [[ -s /etc/wsl.conf ]] || \
+       grep -qi "wsl2" /proc/version || \
+       uname -r | grep -qi "wsl2" || \
+       [ -n "$$WSL_DISTRO_NAME" ] || \
+       which powershell.exe &> /dev/null || \
+       [ -f "/.dockerenv" ]; then \
+        echo 0; \
+    else \
+        echo 1; \
+    fi \
+)
+MONACO_EDITOR ?= $(IS_WSL_OR_DOCKER)
 
 IPA ?= 0
 
@@ -37,6 +49,9 @@ else
 release: run-cmake-release
 	cmake --build build -j $(CPU_CORES)
 endif
+
+check_monaco_editor:
+	@echo "MONACO_EDITOR is set to $(MONACO_EDITOR)"
 
 release_no_tcmalloc: run-cmake-release_no_tcmalloc
 	cmake --build build -j $(CPU_CORES)


### PR DESCRIPTION
When doing a compilation, auto-detect type of environment (WSL, Docker, Native) and set MONACO_EDITOR flag value.