### PR TITLE
Update main.yml to build Raptor exe with monaco in production build in CentOS 7 docker based env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
             [ $? != 0 ] && exit 1
             echo "2nd compilation"
             rm -rvf build/FOEDAG_rs
-            make install MONACO_EDITOR=0 CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
+            make install MONACO_EDITOR=1 CPU_CORES=2 $run_test PRODUCTION_BUILD=1 PREFIX=/opt/instl_dir PRODUCTION_DEVICES=$p_device STICK_RELEASE_VERSION=$r_d
             [ $? != 0 ] && exit 1
             #export LM_LICENSE_FILE=/work/.github/bin/.raptor.lic
             ./build/OPENLM_DIR/licensecc/extern/license-generator/src/license_generator/lccgen license issue -p projects/Raptor -f Raptor,$d_test,DE -o build/bin/raptor.lic


### PR DESCRIPTION
In Makefile we auto-detect the environment and set a flag to on/off the Monaco.
In the production build on CentOS 7, we have to explicitly set the Monaco flag on and then off so that we have executables with Monaco and without Monaco. 