### PR TITLE
Name Raptor exe as raptorm.exe when MONACO_EDITOR=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -628,7 +628,7 @@ install(
 
 if(MONACO_EDITOR)  
   install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exeMonacoEmbed
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/raptorm.exe
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     PERMISSIONS
     OWNER_READ OWNER_EXECUTE OWNER_WRITE
@@ -901,10 +901,10 @@ else ()
         ${CMAKE_CURRENT_BINARY_DIR}/bin/)
   if(MONACO_EDITOR)      
     add_custom_command(TARGET raptor-bin POST_BUILD
-          COMMAND echo "rename raptor binary as raptor.exeMonacoEmbed"
+          COMMAND echo "rename raptor binary as raptorm.exe"
           COMMAND ${CMAKE_COMMAND} -E rename
             ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor
-            ${CMAKE_CURRENT_BINARY_DIR}/bin/raptor.exeMonacoEmbed)
+            ${CMAKE_CURRENT_BINARY_DIR}/bin/raptorm.exe)
   else()
     add_custom_command(TARGET raptor-bin POST_BUILD
     COMMAND echo "rename raptor binary as raptor.exe"

--- a/src/to_be_raptor_linx
+++ b/src/to_be_raptor_linx
@@ -41,7 +41,7 @@ detect_environment() {
 
 environment=$(detect_environment)
 if [ "$environment" == "Native" ]; then
-        RAPTOR_EXE=raptor.exeMonacoEmbed
+        RAPTOR_EXE=raptorm.exe
 else
         RAPTOR_EXE=raptor.exe
 fi


### PR DESCRIPTION
To make the final executable name short and look pretty, rename the final Raptor exe as raptorm.exe when building with the Monaco editor.