### PR TITLE
New synth options, init_registers

### DIFF
--- a/etc/help.txt
+++ b/etc/help.txt
@@ -109,27 +109,31 @@ Tcl commands (Available in GUI or Batch console or Batch script):
 --- Synthesis ---
 -----------------
    synth_options <option list>:
-     -effort <level>          : Optimization effort level (high, medium, low)
-       high                   : Most compute, generally impacting runtime (default)
-       medium                 : Balanced compute
-       low                    : least compute, least runtime
-     -fsm_encoding <encoding> : FSM encoding (binary, onehot)
-       binary                 : Compact encoding - using minimum of registers to cover the N states
-       onehot                 : One hot encoding - using N registers for N states (default)
-     -carry <mode>            : Carry logic inference mode (all, auto, none)
-       all                    : Infer as much as possible
-       auto                   : Infer carries based on internal heuristics (default)
-       none                   : Do not infer carries
-     -clke_strategy <strategy>: Clock enable extraction strategy for FFs (early, late)
-       early                  : Perform early extraction (default)
-       late                   : Perform late extraction
-     -fast                    : Perform the fastest synthesis. QoR can be impacted
-     -no_flatten              : Do not flatten design
-     -no_simplify             : Do not run special simplification algorithms in synthesis
-     -no_tribuf               : Do not preserve I/O tristates
-     -no_adder                : Do not infer adders
-     -inferred_io             : Automatic I/O inference (Default false for eFPGA)
-     -no_inferred_io          : No automatic I/O inference (Default true for FPGA)
+     -effort <level>            : Optimization effort level (high, medium, low)
+       high                     : Most compute, generally impacting runtime (default)
+       medium                   : Balanced compute
+       low                      : least compute, least runtime
+     -fsm_encoding <encoding>   : FSM encoding (binary, onehot)
+       binary                   : Compact encoding - using minimum of registers to cover the N states
+       onehot                   : One hot encoding - using N registers for N states (default)
+     -carry <mode>              : Carry logic inference mode (all, auto, none)
+       all                      : Infer as much as possible
+       auto                     : Infer carries based on internal heuristics (default)
+       none                     : Do not infer carries
+     -clke_strategy <strategy>  : Clock enable extraction strategy for FFs (early, late)
+       early                    : Perform early extraction (default)
+       late                     : Perform late extraction
+     -fast                      : Perform the fastest synthesis. QoR can be impacted
+     -no_flatten                : Do not flatten design
+     -no_simplify               : Do not run special simplification algorithms in synthesis
+     -no_tribuf                 : Do not preserve I/O tristates
+     -no_adder                  : Do not infer adders
+     -inferred_io               : Automatic I/O inference (Default false for eFPGA)
+     -no_inferred_io            : No automatic I/O inference (Default true for FPGA)
+     -read_init_registers <int> : Force initialization to uninitialized registers (0, 1, 2)
+       0                        : Initialize register by '0' (default)
+       1                        : Initialize register by '1'
+       2                        : Leave register unintialized
 <engineering>
      -clke_strategy <strategy>: Clock enable extraction strategy for FFs:
        early                  : Perform early extraction


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please add GH or Jira ID here: EDA-3310
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Which submodule does this change impact ?
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Backend
> - [X] FOEDAG_rs
> - [ ] IP_Catalog
> - [ ] Raptor_Tools
> - [ ] yosys_verific_rs
> - [ ] zephyr-rapidsi-dev
> - [ ] Github CI

> #### What does this pull request change?
> Add news tcl command -read_init_registers that accepts either 0/1/2

> #### Verified that the following tests passed locally before PR was created.
> - [X] make tests/batch_all 
> - [ ] Describe or list testcases run specifically to verify these updates if not covered above.

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
