### PR TITLE
Add -no_sat and -init_registers synth_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,12 @@ Tcl commands (Available in GUI or Batch console or Batch script):
      -no_adder                  : Do not infer adders
      -inferred_io               : Automatic I/O inference (Default false for eFPGA)
      -no_inferred_io            : No automatic I/O inference (Default true for FPGA)
-     -read_init_registers <int> : Force initialization to uninitialized registers (0, 1, 2)
-       0                        : Initialize register by '0' (default)
-       1                        : Initialize register by '1'
-       2                        : Leave register unintialized
-   set_limits <type> <int>    : Sets a user limit on object of type (dsp, bram), specify 0 to disable block inferrence
+     -no_sat                  : Disable SAT solver
+     -init_registers <int>    : Force initialization of uninitialized registers
+       0                      : '0' value means initialize with '0' (Default '0' is used)
+       1                      : '1' value means initialize with '1'
+       2                      : '2' value means leave it uninitialized
+  set_limits <type> <int>     : Sets a user limit on object of type (dsp, bram), specify 0 to disable block inferrence
        dsp                    : Maximum number of usable DSPs
        bram                   : Maximum number of usable BRAMs
        carry_length           : Maximum carry length

--- a/etc/help.txt
+++ b/etc/help.txt
@@ -130,11 +130,11 @@ Tcl commands (Available in GUI or Batch console or Batch script):
      -no_adder                  : Do not infer adders
      -inferred_io               : Automatic I/O inference (Default false for eFPGA)
      -no_inferred_io            : No automatic I/O inference (Default true for FPGA)
-     -read_init_registers <int> : Force initialization to uninitialized registers (0, 1, 2)
-       0                        : Initialize register by '0' (default)
-       1                        : Initialize register by '1'
-       2                        : Leave register unintialized
-<engineering>
+     -no_sat                  : Disable SAT solver
+     -init_registers <int>    : Force initialization of uninitialized registers
+       0                      : '0' value means initialize with '0' (Default '0' is used)
+       1                      : '1' value means initialize with '1'
+       2                      : '2' value means leave it uninitialized<engineering>
      -clke_strategy <strategy>: Clock enable extraction strategy for FFs:
        early                  : Perform early extraction
        late                   : Perform late extraction

--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -120,6 +120,14 @@
                 "stepVal": 1,
                 "arg": "carry_chain_limit"
             },
+            "init_registers_spinbox_ex": {
+                "label": "Init Registers",
+                "widgetType": "spinbox",
+                "minVal": 0,
+                "maxVal": 2,
+                "stepVal": 1,
+                "arg": "init_registers"
+            },
             "no_sat_checkbox": {
                 "label": "No Sat",
                 "widgetType": "checkbox",

--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -120,6 +120,11 @@
                 "stepVal": 1,
                 "arg": "carry_chain_limit"
             },
+            "no_sat_checkbox": {
+                "label": "No Sat",
+                "widgetType": "checkbox",
+                "arg": "no_sat"
+            },
             "fast_checkbox": {
                 "label": "Fast Synthesis",
                 "widgetType": "checkbox",


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X] To address an existing issue. If so, please add GH or Jira ID here: EDA-3310
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Which submodule does this change impact ?
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Backend
> - [X] FOEDAG_rs
> - [ ] IP_Catalog
> - [ ] Raptor_Tools
> - [ ] yosys_verific_rs
> - [ ] zephyr-rapidsi-dev
> - [ ] Github CI

> #### What does this pull request change?
> Add new synth_options "-no_sat" and "-init_registers"

> #### Verified that the following tests passed locally before PR was created.
> - [X] make tests/batch_all 
> - [ ] Describe or list testcases run specifically to verify these updates if not covered above.

> ### Impact of the pull request
> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
